### PR TITLE
stopped gravestones from copying inventory on place to fix #359

### DIFF
--- a/src/openblocks/common/tileentity/TileEntityGrave.java
+++ b/src/openblocks/common/tileentity/TileEntityGrave.java
@@ -100,7 +100,6 @@ public class TileEntityGrave extends SyncedTileEntity implements ISurfaceAttachm
 	public void onBlockPlacedBy(EntityPlayer player, ForgeDirection side, ItemStack stack, float hitX, float hitY, float hitZ) {
 		if (!worldObj.isRemote) {
 			setUsername(player.username);
-			setLoot(player.inventory);
 			sync();
 		}
 	}


### PR DESCRIPTION
This will still allow players to pickup gravestones, but it fixes the dupe.
