### PR TITLE
Fix off-by-one error in ExplosiveEnchantmentsHandler.tryUseEnchantment

### DIFF
--- a/src/main/java/openblocks/enchantments/ExplosiveEnchantmentsHandler.java
+++ b/src/main/java/openblocks/enchantments/ExplosiveEnchantmentsHandler.java
@@ -129,7 +129,7 @@ public class ExplosiveEnchantmentsHandler {
 		@SuppressWarnings("unchecked")
 		Map<Integer, Integer> enchantments = EnchantmentHelper.getEnchantments(armor);
 		Integer ench = enchantments.get(Enchantments.explosive.effectId);
-		if (ench == null || ench > LEVELS.length) return null;
+		if (ench == null || ench >= LEVELS.length) return null;
 		EnchantmentLevel level = LEVELS[ench];
 		if (level == null) return null;
 


### PR DESCRIPTION
ExplosiveEnchantmentsHandler.tryUseEnchantment can throw an array index out of range exception because of an off-by-one error in the check for valid enchantment level
