### PR TITLE
Prevent graves from being destroyed by the same explosion that caused them

### DIFF
--- a/src/main/java/openblocks/common/block/BlockGrave.java
+++ b/src/main/java/openblocks/common/block/BlockGrave.java
@@ -3,6 +3,10 @@ package openblocks.common.block;
 import java.util.Random;
 
 import net.minecraft.block.material.Material;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.Explosion;
+import net.minecraft.world.World;
+import openblocks.common.tileentity.TileEntityGrave;
 
 public class BlockGrave extends OpenBlock {
 
@@ -14,7 +18,28 @@ public class BlockGrave extends OpenBlock {
 		setResistance(2000.0F);
 	}
 
-	@Override
+    @Override
+    public void onBlockExploded(World world, int x, int y, int z, Explosion explosion) {
+        TileEntity tile = world.getTileEntity(x,y,z);
+        if (tile == null || !(tile instanceof TileEntityGrave)) return;
+
+        TileEntityGrave grave = (TileEntityGrave)tile;
+        // prevent grave from being destroyed by same explosion that caused it
+        if(grave.killer != null &&  grave.killer == explosion.exploder) {
+            // delete killer so the next explosion from it can possibly destroy the grave (e.g. wither)
+            grave.setKiller(null);
+            return;
+        }
+
+        this.breakBlock(world, x,y,z, this,0);
+    }
+
+    @Override
+    public boolean canDropFromExplosion(Explosion explosion) {
+        return false;
+    }
+
+    @Override
 	public boolean isOpaqueCube() {
 		return false;
 	}

--- a/src/main/java/openblocks/common/tileentity/TileEntityGrave.java
+++ b/src/main/java/openblocks/common/tileentity/TileEntityGrave.java
@@ -33,6 +33,8 @@ public class TileEntityGrave extends SyncedTileEntity implements IPlaceAwareTile
 	public SyncableBoolean onSoil;
 	private int ticksSinceLastSound = 0;
 
+    public Entity killer;
+
 	private GenericInventory inventory = registerInventoryCallback(new GenericInventory("grave", false, 100));
 
 	public TileEntityGrave() {}
@@ -80,6 +82,8 @@ public class TileEntityGrave extends SyncedTileEntity implements IPlaceAwareTile
 	public void setLoot(IInventory invent) {
 		inventory.copyFrom(invent);
 	}
+
+    public void setKiller(Entity entity) { this.killer = entity; }
 
 	public boolean isOnSoil() {
 		return onSoil.get();


### PR DESCRIPTION
This means no more item/grave loss when a creeper kills a player.
The next explosion should be able to kill it, but currently is not likely because of high blast resistance.

Might also consider overloading dropBlockAsItemWithChance in BlockGrave and drop its contents manually. This way at least no items are destroyed when the grave is broken by an explosion.
