### PR TITLE
Make painted blocks more 'real'

### DIFF
--- a/src/PaintUtils.java.superzanti
+++ b/src/PaintUtils.java.superzanti
@@ -1,0 +1,106 @@
+package openmods.utils.render;
+
+import java.util.Set;
+
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.world.World;
+import openmods.Mods;
+
+import com.google.common.collect.Sets;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.registry.GameRegistry;
+
+public class PaintUtils {
+
+	private final Set<Block> allowed = Sets.newHashSet();
+
+	public static final PaintUtils instance = new PaintUtils();
+
+	protected PaintUtils() {
+		allowed.add(Blocks.stone);
+		allowed.add(Blocks.cobblestone);
+		allowed.add(Blocks.mossy_cobblestone);
+		allowed.add(Blocks.sandstone);
+		allowed.add(Blocks.iron_block);
+		allowed.add(Blocks.stonebrick);
+		allowed.add(Blocks.glass);
+		allowed.add(Blocks.planks);
+		allowed.add(Blocks.dirt);
+		allowed.add(Blocks.log);
+		allowed.add(Blocks.log2);
+		allowed.add(Blocks.gold_block);
+		allowed.add(Blocks.emerald_block);
+		allowed.add(Blocks.lapis_block);
+		allowed.add(Blocks.quartz_block);
+		allowed.add(Blocks.end_stone);
+		allowed.add(Blocks.leaves);
+		allowed.add(Blocks.leaves2);
+		if (Loader.isModLoaded(Mods.TINKERSCONSTRUCT)) {
+			addBlocksForMod(Mods.TINKERSCONSTRUCT,
+					"GlassBlock",
+					"decoration.multibrick",
+					"decoration.multibrickfancy",
+					"leaves");
+		}
+		if (Loader.isModLoaded(Mods.EXTRAUTILITIES)) {
+			addBlocksForMod(Mods.EXTRAUTILITIES,
+					"greenScreen",
+					"extrautils:decor");
+		}
+		if (Loader.isModLoaded(Mods.BIOMESOPLENTY)) {
+			addBlocksForMod(Mods.BIOMESOPLENTY,
+					"bop.planks",
+					"appleLeaves",
+					"persimmonLeaves",
+					"leaves1",
+					"leaves2",
+					"leaves3",
+					"leaves4",
+					"colorizedLeaves1",
+					"colorizedLeaves2");
+		}
+		if (Loader.isModLoaded("Natura")) {
+			addBlocksForMod("Natura",
+				"floraleaves",
+				"floraleavesnocolor",
+				"Dark Leaves",
+				"Rare Leaves");
+				
+		}
+		if (Loader.isModLoaded("TwilightForest")) {
+			addBlocksForMod("TwilightForest",
+				"TFLeaves",
+				"TFMagicLeaves",
+				"TFLeaves3",
+				"DarkLeaves",
+				"GiantLeaves");
+		}
+		if (Loader.isModLoaded("chisel")) {
+			addBlocksForMod("chisel",
+				"leaves");
+		}
+		if (Loader.isModLoaded("IC2")) {
+			addBlocksForMod("IC2",
+				"blockRubLeaves");
+		}
+	}
+
+	protected void addBlocksForMod(String modId, String... blocks) {
+		for (String blockName : blocks) {
+			Block block = GameRegistry.findBlock(modId, blockName);
+			if (block != null) allowed.add(block);
+		}
+	}
+
+	public boolean isAllowedToReplace(Block block) {
+		if (block == null || block.canProvidePower()) return false;
+		return block.isNormalCube() || allowed.contains(block) || block.getRenderType() == 0 ;
+	}
+
+	public boolean isAllowedToReplace(World world, int x, int y, int z) {
+		if (world.isAirBlock(x, y, z)) { return false; }
+		return isAllowedToReplace(world.getBlock(x, y, z));
+	}
+}

--- a/src/main/java/openblocks/common/block/BlockCanvas.java
+++ b/src/main/java/openblocks/common/block/BlockCanvas.java
@@ -16,6 +16,21 @@ import openmods.infobook.BookDocumentation;
 import openmods.utils.ColorUtils;
 import openmods.utils.ColorUtils.ColorMeta;
 
+import net.minecraft.client.particle.EffectRenderer;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.ChunkCoordinates;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.Vec3;
+import net.minecraftforge.common.IPlantable;
+import net.minecraft.entity.player.EntityPlayer;
+
 @BookDocumentation
 public class BlockCanvas extends OpenBlock implements IPaintableBlock {
 
@@ -45,6 +60,623 @@ public class BlockCanvas extends OpenBlock implements IPaintableBlock {
 		for (Stencil stencil : Stencil.values())
 			stencil.registerBlockIcons(registry);
 	}
+	
+	@Override
+	public float getPlayerRelativeBlockHardness(EntityPlayer A, World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getPlayerRelativeBlockHardness(A, world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getPlayerRelativeBlockHardness(A, world, x, y, z);
+		return block.getPlayerRelativeBlockHardness(A, world, x, y, z);
+	}
+	
+	@Override
+	public boolean addDestroyEffects(World world, int x, int y, int z, int A, EffectRenderer B){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.addDestroyEffects(world, x, y, z, A, B);
+		Block block = tile.getPaintedBlock();
+		int meta = tile.getPaintedBlockMeta();
+		if (block == Blocks.air)
+			return super.addDestroyEffects(world, x, y, z, meta, B);
+		return block.addDestroyEffects(world, x, y, z, meta, B);
+	}
+
+	@Override
+	public boolean canBeReplacedByLeaves(IBlockAccess world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.canBeReplacedByLeaves(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.canBeReplacedByLeaves(world, x, y, z);
+		return block.canBeReplacedByLeaves(world, x, y, z);
+	}
+
+	@Override
+	public boolean canBlockStay(World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.canBlockStay(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.canBlockStay(world, x, y, z);
+		return block.canBlockStay(world, x, y, z);
+	}
+
+	@Override
+	public boolean canEntityDestroy(IBlockAccess world, int x, int y, int z, Entity entity){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.canEntityDestroy(world, x, y, z, entity);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.canEntityDestroy(world, x, y, z, entity);
+		return block.canEntityDestroy(world, x, y, z, entity);
+	}
+	
+	@Override
+	public boolean canPlaceTorchOnTop(World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.canPlaceTorchOnTop(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.canPlaceTorchOnTop(world, x, y, z);
+		return block.canPlaceTorchOnTop(world, x, y, z);
+	}
+	
+	@Override
+	public boolean canPlaceBlockAt(World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.canPlaceBlockAt(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.canPlaceBlockAt(world, x, y, z);
+		return block.canPlaceBlockAt(world, x, y, z);
+	}
+
+	@Override
+	public boolean canSustainLeaves(IBlockAccess world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.canSustainLeaves(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.canSustainLeaves(world, x, y, z);
+		return block.canSustainLeaves(world, x, y, z);
+	}
+
+	@Override
+	public boolean canSustainPlant(IBlockAccess world, int x, int y, int z, ForgeDirection A, IPlantable B){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.canSustainPlant(world, x, y, z, A, B);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.canSustainPlant(world, x, y, z, A, B);
+		return block.canSustainPlant(world, x, y, z, A, B);
+	}
+
+	@Override
+	public MovingObjectPosition collisionRayTrace(World world, int x, int y, int z, Vec3 A, Vec3 B){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.collisionRayTrace(world, x, y, z, A, B);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.collisionRayTrace(world, x, y, z, A, B);
+		return block.collisionRayTrace(world, x, y, z, A, B);
+	}
+	
+	@Override
+	public boolean isLeaves(IBlockAccess world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.isLeaves(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block.isLeaves(world, x, y, z))
+			return true;
+		else
+			return super.isLeaves(world, x, y, z);
+	}
+	
+	@Override
+	public boolean getBlocksMovement(IBlockAccess world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getBlocksMovement(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getBlocksMovement(world, x, y, z);
+		return block.getBlocksMovement(world, x, y, z);
+	}
+
+	@Override
+	public AxisAlignedBB getCollisionBoundingBoxFromPool(World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getCollisionBoundingBoxFromPool(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getCollisionBoundingBoxFromPool(world, x, y, z);
+		return block.getCollisionBoundingBoxFromPool(world, x, y, z);
+	}
+
+	@Override
+	public int getComparatorInputOverride(World world, int x, int y, int z, int A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getComparatorInputOverride(world, x, y, z, A);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getComparatorInputOverride(world, x, y, z, A);
+		return block.getComparatorInputOverride(world, x, y, z, A);
+	}
+
+	@Override
+	public int getDamageValue(World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getDamageValue(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getDamageValue(world, x, y, z);
+		return block.getDamageValue(world, x, y, z);
+	}
+	
+	@Override
+	public float getEnchantPowerBonus(World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getEnchantPowerBonus(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getEnchantPowerBonus(world, x, y, z);
+		return block.getEnchantPowerBonus(world, x, y, z);
+	}
+
+	@Override
+	public float getExplosionResistance(Entity A, World world, int x, int y, int z, double B, double C, double D){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getExplosionResistance(A, world, x, y, z, B, C, D);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getExplosionResistance(A, world, x, y, z, B, C, D);
+		return block.getExplosionResistance(A, world, x, y, z, B, C, D);
+	}
+
+	@Override
+	public int getFireSpreadSpeed(IBlockAccess world, int x, int y, int z, ForgeDirection A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getFireSpreadSpeed(world, x, y, z, A);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getFireSpreadSpeed(world, x, y, z, A);
+		return block.getFireSpreadSpeed(world, x, y, z, A);
+	}
+
+	@Override
+	public int getFlammability(IBlockAccess world, int x, int y, int z, ForgeDirection A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getFlammability(world, x, y, z, A);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getFlammability(world, x, y, z, A);
+		return block.getFlammability(world, x, y, z, A);
+	}
+
+	@Override
+	public ItemStack getPickBlock(MovingObjectPosition A, World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getPickBlock(A, world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getPickBlock(A, world, x, y, z);
+		return block.getPickBlock(A, world, x, y, z);
+	}
+	
+	@Override
+	public AxisAlignedBB getSelectedBoundingBoxFromPool(World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getSelectedBoundingBoxFromPool(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getSelectedBoundingBoxFromPool(world, x, y, z);
+		return block.getSelectedBoundingBoxFromPool(world, x, y, z);
+	}
+
+	@Override
+	public ForgeDirection[] getValidRotations(World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getValidRotations(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getValidRotations(world, x, y, z);
+		return block.getValidRotations(world, x, y, z);
+	}
+
+	@Override
+	public boolean getWeakChanges(IBlockAccess world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getWeakChanges(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getWeakChanges(world, x, y, z);
+		return block.getWeakChanges(world, x, y, z);
+	}
+	
+	@Override
+	public boolean isBlockSolid(IBlockAccess world, int x, int y, int z, int A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.isBlockSolid(world, x, y, z, A);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.isBlockSolid(world, x, y, z, A);
+		return block.isBlockSolid(world, x, y, z, A);
+	}
+
+	@Override
+	public boolean isBurning(IBlockAccess world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.isBurning(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.isBurning(world, x, y, z);
+		return block.isBurning(world, x, y, z);
+	}
+
+	@Override
+	public boolean isFertile(World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.isFertile(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.isFertile(world, x, y, z);
+		return block.isFertile(world, x, y, z);
+	}
+
+	@Override
+	public boolean isFireSource(World world, int x, int y, int z, ForgeDirection A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.isFireSource(world, x, y, z, A);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.isFireSource(world, x, y, z, A);
+		return block.isFireSource(world, x, y, z, A);
+	}
+
+	@Override
+	public boolean isFlammable(IBlockAccess world, int x, int y, int z, ForgeDirection A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.isFlammable(world, x, y, z, A);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.isFlammable(world, x, y, z, A);
+		return block.isFlammable(world, x, y, z, A);
+	}
+	
+	@Override
+	public int isProvidingStrongPower(IBlockAccess world, int x, int y, int z, int A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.isProvidingStrongPower(world, x, y, z, A);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.isProvidingStrongPower(world, x, y, z, A);
+		return block.isProvidingStrongPower(world, x, y, z, A);
+	}
+
+	@Override
+	public int isProvidingWeakPower(IBlockAccess world, int x, int y, int z, int A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.isProvidingWeakPower(world, x, y, z, A);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.isProvidingWeakPower(world, x, y, z, A);
+		return block.isProvidingWeakPower(world, x, y, z, A);
+	}
+
+	@Override
+	public boolean isWood(IBlockAccess world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.isWood(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.isWood(world, x, y, z);
+		return block.isWood(world, x, y, z);
+	}
+
+	@Override
+	public boolean onBlockEventReceived(World world, int x, int y, int z, int A, int B){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.onBlockEventReceived(world, x, y, z, A, B);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.onBlockEventReceived(world, x, y, z, A, B);
+		return block.onBlockEventReceived(world, x, y, z, A, B);
+	}
+
+	@Override
+	public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.rotateBlock(world, x, y, z, A);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.rotateBlock(world, x, y, z, A);
+		return block.rotateBlock(world, x, y, z, A);
+	}
+
+	@Override
+	public boolean shouldCheckWeakPower(IBlockAccess world, int x, int y, int z, int A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.shouldCheckWeakPower(world, x, y, z, A);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.shouldCheckWeakPower(world, x, y, z, A);
+		return block.shouldCheckWeakPower(world, x, y, z, A);
+	}
+	
+	@Override
+	public void addCollisionBoxesToList(World world, int x, int y, int z, AxisAlignedBB A, java.util.List B, Entity C){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.addCollisionBoxesToList(world, x, y, z, A, B, C);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.addCollisionBoxesToList(world, x, y, z, A, B, C);
+			return;
+		}
+		block.addCollisionBoxesToList(world, x, y, z, A, B, C);
+		return;
+	}
+
+	@Override
+	public void breakBlock(World world, int x, int y, int z, Block A, int B){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.breakBlock(world, x, y, z, A, B);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.breakBlock(world, x, y, z, A, B);
+			return;
+		}
+		block.breakBlock(world, x, y, z, A, B);
+		return;
+	}
+
+	@Override
+	public void fillWithRain(World world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.fillWithRain(world, x, y, z);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.fillWithRain(world, x, y, z);
+			return;
+		}
+		block.fillWithRain(world, x, y, z);
+		return;
+	}
+
+	@Override
+	public void onBlockClicked(World world, int x, int y, int z, EntityPlayer A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.onBlockClicked(world, x, y, z, A);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.onBlockClicked(world, x, y, z, A);
+			return;
+		}
+		block.onBlockClicked(world, x, y, z, A);
+		return;
+	}
+
+	@Override
+	public void onEntityCollidedWithBlock(World world, int x, int y, int z, Entity A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.onEntityCollidedWithBlock(world, x, y, z, A);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.onEntityCollidedWithBlock(world, x, y, z, A);
+			return;
+		}
+		block.onEntityCollidedWithBlock(world, x, y, z, A);
+		return;
+	}
+
+	@Override
+	public void onEntityWalking(World world, int x, int y, int z, Entity A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.onEntityWalking(world, x, y, z, A);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.onEntityWalking(world, x, y, z, A);
+			return;
+		}
+		block.onEntityWalking(world, x, y, z, A);
+		return;
+	}
+
+	@Override
+	public void onFallenUpon(World world, int x, int y, int z, Entity A, float B){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.onFallenUpon(world, x, y, z, A, B);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.onFallenUpon(world, x, y, z, A, B);
+			return;
+		}
+		block.onFallenUpon(world, x, y, z, A, B);
+		return;
+	}
+
+	@Override
+	public void onNeighborBlockChange(World world, int x, int y, int z, Block A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.onNeighborBlockChange(world, x, y, z, A);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.onNeighborBlockChange(world, x, y, z, A);
+			return;
+		}
+		block.onNeighborBlockChange(world, x, y, z, A);
+		return;
+	}
+
+	@Override
+	public void onNeighborChange(IBlockAccess world, int x, int y, int z, int A, int B, int C){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.onNeighborChange(world, x, y, z, A, B, C);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.onNeighborChange(world, x, y, z, A, B, C);
+			return;
+		}
+		block.onNeighborChange(world, x, y, z, A, B, C);
+		return;
+	}
+
+	@Override
+	public void onPlantGrow(World world, int x, int y, int z, int A, int B, int C){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.onPlantGrow(world, x, y, z, A, B, C);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.onPlantGrow(world, x, y, z, A, B, C);
+			return;
+		}
+		block.onPlantGrow(world, x, y, z, A, B, C);
+		return;
+	}
+
+	@Override
+	public void setBlockBoundsBasedOnState(IBlockAccess world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.setBlockBoundsBasedOnState(world, x, y, z);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.setBlockBoundsBasedOnState(world, x, y, z);
+			return;
+		}
+		block.setBlockBoundsBasedOnState(world, x, y, z);
+		return;
+	}
+
+	@Override
+	public void velocityToAddToEntity(World world, int x, int y, int z, Entity A, Vec3 B){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.velocityToAddToEntity(world, x, y, z, A, B);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.velocityToAddToEntity(world, x, y, z, A, B);
+			return;
+		}
+		block.velocityToAddToEntity(world, x, y, z, A, B);
+		return;
+	}
+	
+	@Override
+	public void updateTick(World world, int x, int y, int z, java.util.Random A){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null){
+			super.updateTick(world, x, y, z, A);
+			return;
+		}
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air){
+			super.updateTick(world, x, y, z, A);
+			return;
+		}
+		block.updateTick(world, x, y, z, A);
+		return;
+	}
+	
+	@Override
+	public int getLightOpacity(IBlockAccess world, int x, int y, int z){
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return super.getLightOpacity(world, x, y, z);
+		Block block = tile.getPaintedBlock();
+		if (block == Blocks.air)
+			return super.getLightOpacity(world, x, y, z);
+		return block.getLightOpacity(world, x, y, z);
+	}
+	
+	@Override
+	public boolean isOpaqueCube() {
+		return false;
+	}
+	
+	@Override
+	public boolean canRenderInPass(int pass){
+		if (pass == 1)
+			return true;
+		return false;
+	}
+	
+	@Override
+	public int getRenderBlockPass(){
+		return 1;
+	}
+
+	@Override
+	public boolean renderAsNormalBlock() {
+		return false;
+	}
 
 	public void setLayerForRender(int layer) {
 		this.layer = layer;
@@ -56,17 +688,23 @@ public class BlockCanvas extends OpenBlock implements IPaintableBlock {
 
 	@Override
 	public boolean shouldSideBeRendered(IBlockAccess world, int x, int y, int z, int side) {
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		if (tile == null)
+			return (renderSide == RENDER_ALL_SIDES || side == renderSide) && super.shouldSideBeRendered(world, x, y, z, side);
+		Block block = tile.getPaintedBlock();
+		if (block == this || block == Blocks.glass || !block.isOpaqueCube() || block.canRenderInPass(1)) { return false; }
 		return (renderSide == RENDER_ALL_SIDES || side == renderSide) && super.shouldSideBeRendered(world, x, y, z, side);
 	}
 
 	@Override
 	public int colorMultiplier(IBlockAccess world, int x, int y, int z) {
+		TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
+		Block block = tile.getPaintedBlock();
 		if (layer != NO_LAYER) {
-			TileEntityCanvas tile = getTileEntity(world, x, y, z, TileEntityCanvas.class);
 			if (tile != null) return tile.getColorForRender(renderSide, layer);
 		}
 
-		return 0xFFFFFFFF;
+		return block.colorMultiplier(world, x, y, z);
 	}
 
 	@Override
@@ -90,7 +728,7 @@ public class BlockCanvas extends OpenBlock implements IPaintableBlock {
 			world.setBlock(x, y, z, OpenBlocks.Blocks.canvas);
 		}
 		TileEntityCanvas tile = (TileEntityCanvas)world.getTileEntity(x, y, z);
-		tile.setPaintedBlockBlock(block, meta);
+		tile.setPaintedBlockBlock(block, meta, block.colorMultiplier(world, x, y, z));
 	}
 
 	@Override

--- a/src/main/java/openblocks/common/item/ItemPaintBrush.java
+++ b/src/main/java/openblocks/common/item/ItemPaintBrush.java
@@ -82,7 +82,7 @@ public class ItemPaintBrush extends Item {
 		Integer color = getColorFromStack(stack);
 		if (stack.getItemDamage() > getMaxDamage() || color == null) return true;
 
-		if (PaintUtils.instance.isAllowedToReplace(world, x, y, z)) {
+		if (PaintUtils.instance.isAllowedToReplace(world, x, y, z) && world.getBlock(x, y, z) != OpenBlocks.Blocks.canvasGlass && world.getBlock(x, y, z) != OpenBlocks.Blocks.canvas) {
 			BlockCanvas.replaceBlock(world, x, y, z);
 		}
 

--- a/src/main/java/openblocks/common/tileentity/TileEntityCanvas.java
+++ b/src/main/java/openblocks/common/tileentity/TileEntityCanvas.java
@@ -29,6 +29,8 @@ import openmods.tileentity.SyncedTileEntity;
 import openmods.utils.BlockNotifyFlags;
 import openmods.utils.BlockUtils;
 
+import net.minecraft.world.IBlockAccess;
+
 public class TileEntityCanvas extends SyncedTileEntity implements IActivateAwareTile, ICustomBreakDrops, ICustomHarvestDrops {
 
 	public static final int[] ALL_SIDES = { 0, 1, 2, 3, 4, 5 };
@@ -80,11 +82,14 @@ public class TileEntityCanvas extends SyncedTileEntity implements IActivateAware
 		final SyncableBlockLayers layers = getLayersForSide(renderSide);
 		return layers != null? layers.getLayer(layerId) : null;
 	}
+	
+	public void setDefaultColors(int defaultColor){
+	}
 
 	public int getColorForRender(int renderSide, int layerId) {
 		if (layerId == BlockCanvas.BASE_LAYER) return baseColors.getValue(renderSide);
 		final Layer layer = getLayerForSide(renderSide, layerId);
-		return layer != null? layer.getColorForRender() : 0xCCCCCC;
+		return layer != null? layer.getColorForRender() : 0xFEFEFE;
 	}
 
 	public IIcon getTextureForRender(int renderSide, int layerId) {
@@ -102,6 +107,14 @@ public class TileEntityCanvas extends SyncedTileEntity implements IActivateAware
 		Block block = paintedBlock.getValue();
 		if (block == Blocks.air) return OpenBlocks.Blocks.canvas.baseIcon;
 		return block.getIcon(side, paintedBlockMeta.get());
+	}
+	
+	public Block getPaintedBlock() {
+		return paintedBlock.getValue();
+	}
+	
+	public int getPaintedBlockMeta() {
+		return paintedBlockMeta.get();
 	}
 
 	@Override
@@ -251,8 +264,11 @@ public class TileEntityCanvas extends SyncedTileEntity implements IActivateAware
 		}
 	}
 
-	public void setPaintedBlockBlock(Block block, int meta) {
+	public void setPaintedBlockBlock(Block block, int meta, int color) {
 		paintedBlock.setValue(block);
 		paintedBlockMeta.set(meta);
+		for(int i = 0; i < 6; i++){
+			baseColors.setValue(i, color);
+		}
 	}
 }


### PR DESCRIPTION
I added some stuff specifically in BlockCanvas.java that makes it so any painted block acts more like the block that they were originally instead of a canvas. For example, painted netherrack can still sustain fire, leaves will disappear if they are not attached to wood, painted wood can still sustain leaves.

I think the best addition however is that the mining speed is the same as the original block. This prevents cheating. I was using this mod on my server and people would paint obsidian and then mine the now canvas block. They would then get a piece of obsidian as a drop without nearly any mining time. Users would also do this for things that they couldn't mine such as iron and diamond.

This addition makes many more blocks paintable and adds some fairness to the mod. It's not perfect, but I think it's better.