### PR TITLE
Allow broken sky blocks to stack with their respective types

### DIFF
--- a/src/main/java/openblocks/common/block/BlockSky.java
+++ b/src/main/java/openblocks/common/block/BlockSky.java
@@ -1,12 +1,15 @@
 package openblocks.common.block;
 
+import java.util.ArrayList;
 import java.util.Random;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.world.World;
+import openblocks.OpenBlocks;
 import openmods.infobook.BookDocumentation;
 import openmods.utils.BlockNotifyFlags;
 import openmods.utils.render.RenderUtils;
@@ -68,4 +71,10 @@ public class BlockSky extends OpenBlock {
 		return isActive(meta)? AxisAlignedBB.getBoundingBox(0, 0, 0, 0, 0, 0) : super.getSelectedBoundingBoxFromPool(world, x, y, z);
 	}
 
+	@Override
+	public ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune) {
+		ArrayList<ItemStack> arr = new ArrayList<ItemStack>();
+		arr.add(new ItemStack(OpenBlocks.Blocks.sky, 1, metadata == 0 || metadata == 2 ? 0 : 1));
+		return arr;
+	}
 }


### PR DESCRIPTION
The previous behavior was that sky blocks would drop an ItemStack with the metadata in world. e.g. if a normal sky block was active in the world (metadata 2) and was broken, the resulting stack would have metadata 2 and not be able to stack with normal, crafted sky blocks (metadata 0) and have to be replaced in the world, and forced to update to restore them to metadata 0. Now, active and inactive normal sky blocks always drop metadata 0, and active and inactive inverted sky blocks always drop metadata 1