### PR TITLE
Ore Dictionary support for recipes

### DIFF
--- a/src/main/java/openblocks/Config.java
+++ b/src/main/java/openblocks/Config.java
@@ -315,11 +315,11 @@ public class Config {
 		}
 
 		if (OpenBlocks.Blocks.guide != null) {
-			recipeList.add(new ShapedOreRecipe(OpenBlocks.Blocks.guide, "grg", "gtg", "grg", 'g', "blockGlass", 't', Blocks.torch, 'r', Items.redstone));
+			recipeList.add(new ShapedOreRecipe(OpenBlocks.Blocks.guide, "grg", "gtg", "grg", 'g', "blockGlass", 't', Blocks.torch, 'r', "dustRedstone"));
 		}
 
 		if (OpenBlocks.Blocks.builderGuide != null) {
-			recipeList.add(new ShapedOreRecipe(OpenBlocks.Blocks.builderGuide, "grg", "ete", "grg", 'g', "blockGlass", 't', Blocks.torch, 'r', Items.redstone, 'e', Items.ender_pearl));
+			recipeList.add(new ShapedOreRecipe(OpenBlocks.Blocks.builderGuide, "grg", "ete", "grg", 'g', "blockGlass", 't', Blocks.torch, 'r', "dustRedstone", 'e', Items.ender_pearl));
 		}
 
 		if (OpenBlocks.Blocks.elevator != null) {
@@ -356,7 +356,7 @@ public class Config {
 		}
 
 		if (OpenBlocks.Blocks.cannon != null) {
-			recipeList.add(new ShapedOreRecipe(OpenBlocks.Blocks.cannon, " d ", " f ", "iri", 'd', Blocks.dispenser, 'f', Blocks.iron_bars, 'i', "ingotIron", 'r', Blocks.redstone_block));
+			recipeList.add(new ShapedOreRecipe(OpenBlocks.Blocks.cannon, " d ", " f ", "iri", 'd', Blocks.dispenser, 'f', Blocks.iron_bars, 'i', "ingotIron", 'r', "blockRedstone"));
 		}
 
 		if (OpenBlocks.Blocks.vacuumHopper != null) {
@@ -436,7 +436,7 @@ public class Config {
 				ChestGenHooks.getInfo(ChestGenHooks.DUNGEON_CHEST).addItem(drop);
 				ChestGenHooks.getInfo(ChestGenHooks.MINESHAFT_CORRIDOR).addItem(drop);
 			}
-			recipeList.add(new ShapedOreRecipe(OpenBlocks.Blocks.donationStation, "ppp", "pcp", "ppp", 'p', Items.porkchop, 'c', Blocks.chest));
+			recipeList.add(new ShapedOreRecipe(OpenBlocks.Blocks.donationStation, "ppp", "pcp", "ppp", 'p', Items.porkchop, 'c', "chestWood"));
 		}
 
 		if (OpenBlocks.Blocks.paintMixer != null) {
@@ -466,7 +466,7 @@ public class Config {
 		}
 
 		if (OpenBlocks.Blocks.drawingTable != null) {
-			recipeList.add(new ShapedOreRecipe(OpenBlocks.Blocks.drawingTable, "sks", "pcp", "ppp", 'p', "plankWood", 'c', Blocks.crafting_table, 's', MetasGeneric.unpreparedStencil.newItemStack(), 'k', MetasGeneric.sketchingPencil.newItemStack()));
+			recipeList.add(new ShapedOreRecipe(OpenBlocks.Blocks.drawingTable, "sks", "pcp", "ppp", 'p', "plankWood", 'c', "craftingTableWood", 's', MetasGeneric.unpreparedStencil.newItemStack(), 'k', MetasGeneric.sketchingPencil.newItemStack()));
 		}
 
 		if (OpenBlocks.Blocks.xpShower != null) {
@@ -490,7 +490,7 @@ public class Config {
 		}
 
 		if (OpenBlocks.Items.luggage != null) {
-			recipeList.add(new ShapedOreRecipe(OpenBlocks.Items.luggage, "sds", "scs", "sss", 's', "stickWood", 'd', "gemDiamond", 'c', Blocks.chest));
+			recipeList.add(new ShapedOreRecipe(OpenBlocks.Items.luggage, "sds", "scs", "sss", 's', "stickWood", 'd', "gemDiamond", 'c', "chestWood"));
 		}
 
 		if (OpenBlocks.Items.sonicGlasses != null) {

--- a/src/main/java/openblocks/OpenBlocks.java
+++ b/src/main/java/openblocks/OpenBlocks.java
@@ -7,6 +7,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.EntityList;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.stats.Achievement;
 import net.minecraft.stats.StatBase;
 import net.minecraft.stats.StatBasic;
@@ -15,6 +16,7 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.oredict.OreDictionary;
 import openblocks.common.*;
 import openblocks.common.block.*;
 import openblocks.common.entity.*;
@@ -471,6 +473,7 @@ public class OpenBlocks {
 		FMLCommonHandler.instance().bus().register(new ServerTickHandler());
 		proxy.init();
 		proxy.registerRenderInformation();
+		registerOreDictionary();
 	}
 
 	@EventHandler
@@ -524,5 +527,10 @@ public class OpenBlocks {
 
 	public static String getModId() {
 		return OpenBlocks.class.getAnnotation(Mod.class).modid();
+	}
+
+	private static void registerOreDictionary() {
+		OreDictionary.registerOre("craftingTableWood", new ItemStack(net.minecraft.init.Blocks.crafting_table));
+		OreDictionary.registerOre("chestWood", new ItemStack(net.minecraft.init.Blocks.chest));
 	}
 }

--- a/src/main/java/openblocks/common/item/MetasGeneric.java
+++ b/src/main/java/openblocks/common/item/MetasGeneric.java
@@ -29,8 +29,8 @@ public enum MetasGeneric {
 		public IMetaItem createMetaItem() {
 			ItemStack result = newItemStack(2);
 			return new MetaGeneric("beam",
-					new ShapedOreRecipe(result, "iii", "b y", "iii", 'i', Items.iron_ingot, 'b', "dyeBlack", 'y', "dyeYellow"),
-					new ShapedOreRecipe(result, "iii", "y b", "iii", 'i', Items.iron_ingot, 'b', "dyeBlack", 'y', "dyeYellow")
+					new ShapedOreRecipe(result, "iii", "b y", "iii", 'i', "ingotIron", 'b', "dyeBlack", 'y', "dyeYellow"),
+					new ShapedOreRecipe(result, "iii", "y b", "iii", 'i', "ingotIron", 'b', "dyeBlack", 'y', "dyeYellow")
 			);
 		}
 	},
@@ -39,7 +39,7 @@ public enum MetasGeneric {
 		public IMetaItem createMetaItem() {
 			ItemStack result = newItemStack();
 			return new MetaGeneric("crane_engine",
-					new ShapedOreRecipe(result, "iii", "isi", "iri", 'i', Items.iron_ingot, 's', "stickWood", 'r', Items.redstone)
+					new ShapedOreRecipe(result, "iii", "isi", "iri", 'i', "ingotIron", 's', "stickWood", 'r', "dustRedstone")
 			);
 		}
 	},
@@ -48,8 +48,8 @@ public enum MetasGeneric {
 		public IMetaItem createMetaItem() {
 			ItemStack result = newItemStack();
 			return new MetaGeneric("crane_magnet",
-					new ShapedOreRecipe(result, "biy", "iri", 'i', Items.iron_ingot, 'r', Items.redstone, 'b', "dyeBlack", 'y', "dyeYellow"),
-					new ShapedOreRecipe(result, "yib", "iri", 'i', Items.iron_ingot, 'r', Items.redstone, 'b', "dyeBlack", 'y', "dyeYellow")
+					new ShapedOreRecipe(result, "biy", "iri", 'i', "ingotIron", 'r', "dustRedstone", 'b', "dyeBlack", 'y', "dyeYellow"),
+					new ShapedOreRecipe(result, "yib", "iri", 'i', "ingotIron", 'r', "dustRedstone", 'b', "dyeBlack", 'y', "dyeYellow")
 			);
 		}
 	},
@@ -59,8 +59,8 @@ public enum MetasGeneric {
 			ItemStack result = newItemStack();
 			ItemStack magnet = craneMagnet.newItemStack();
 			return new MetaMiracleMagnet("miracle_magnet",
-					new ShapedOreRecipe(result, "rer", "eme", "rer", 'r', Items.redstone, 'e', Items.ender_pearl, 'm', magnet),
-					new ShapedOreRecipe(result, "ere", "rmr", "ere", 'r', Items.redstone, 'e', Items.ender_pearl, 'm', magnet)
+					new ShapedOreRecipe(result, "rer", "eme", "rer", 'r', "dustRedstone", 'e', Items.ender_pearl, 'm', magnet),
+					new ShapedOreRecipe(result, "ere", "rmr", "ere", 'r', "dustRedstone", 'e', Items.ender_pearl, 'm', magnet)
 			);
 		}
 
@@ -74,7 +74,7 @@ public enum MetasGeneric {
 		public IMetaItem createMetaItem() {
 			ItemStack result = newItemStack(2);
 			return new MetaGeneric("line",
-					new ShapedOreRecipe(result, "sss", "bbb", "sss", 's', Items.string, 'b', Items.slime_ball)
+					new ShapedOreRecipe(result, "sss", "bbb", "sss", 's', Items.string, 'b', "slimeball")
 			);
 		}
 	},
@@ -83,7 +83,7 @@ public enum MetasGeneric {
 		public IMetaItem createMetaItem() {
 			ItemStack result = newItemStack(1);
 			return new MetaGeneric("map_controller",
-					new ShapedOreRecipe(result, " r ", "rgr", " r ", 'r', Items.redstone, 'g', Items.gold_ingot)
+					new ShapedOreRecipe(result, " r ", "rgr", " r ", 'r', "dustRedstone", 'g', "ingotGold")
 			);
 		}
 	},
@@ -92,7 +92,7 @@ public enum MetasGeneric {
 		public IMetaItem createMetaItem() {
 			ItemStack result = newItemStack(1);
 			return new MetaGeneric("map_memory",
-					new ShapedOreRecipe(result, "rg", "rg", "rg", 'g', Items.gold_nugget, 'r', Items.redstone)
+					new ShapedOreRecipe(result, "rg", "rg", "rg", 'g', "nuggetGold", 'r', "dustRedstone")
 			);
 		}
 	},
@@ -117,7 +117,7 @@ public enum MetasGeneric {
 		public IMetaItem createMetaItem() {
 			ItemStack result = newItemStack();
 			return new MetaGeneric("assistant_base",
-					new ShapedOreRecipe(result, "iei", "iri", 'i', Items.iron_ingot, 'e', Items.ender_pearl, 'r', Items.redstone)
+					new ShapedOreRecipe(result, "iei", "iri", 'i', "ingotIron", 'e', Items.ender_pearl, 'r', "dustRedstone")
 			);
 		}
 	},
@@ -126,7 +126,7 @@ public enum MetasGeneric {
 		public IMetaItem createMetaItem() {
 			ItemStack result = newItemStack();
 			return new MetaGeneric("unprepared_stencil",
-					new ShapedOreRecipe(result, " p ", "pip", " p ", 'p', Items.paper, 'i', Items.iron_ingot)
+					new ShapedOreRecipe(result, " p ", "pip", " p ", 'p', Items.paper, 'i', "ingotIron")
 			);
 		}
 	},
@@ -135,7 +135,7 @@ public enum MetasGeneric {
 		public IMetaItem createMetaItem() {
 			ItemStack result = newItemStack();
 			return new MetaGeneric("sketching_pencil",
-					new ShapedOreRecipe(result, "c  ", " s ", "  s", 'c', new ItemStack(Items.coal, 1, OreDictionary.WILDCARD_VALUE), 's', Items.stick)
+					new ShapedOreRecipe(result, "c  ", " s ", "  s", 'c', new ItemStack(Items.coal, 1, OreDictionary.WILDCARD_VALUE), 's', "stickWood")
 			);
 		}
 	};


### PR DESCRIPTION
Converted all recipes to use Ore Dictionary
Chests and Crafting tables were registered for better compatibility with ganymedes01's [WoodStuff mod](https://github.com/ganymedes01/WoodStuff)
@boq you can move Ore Dictionary registration to a better place. I just don't know which place you will prefer for this.