### PR TITLE
minor performance in model rendering

### DIFF
--- a/src/main/java/openblocks/client/model/AbstractModel.java
+++ b/src/main/java/openblocks/client/model/AbstractModel.java
@@ -1,7 +1,14 @@
 package openblocks.client.model;
 
 import net.minecraft.client.model.ModelBase;
+import net.minecraft.client.model.ModelRenderer;
 
 public abstract class AbstractModel extends ModelBase {
 	protected static final float SCALE = 1.0f / 16.0f;
+	
+	protected static void setRotation(ModelRenderer model, float x, float y, float z) {
+		model.rotateAngleX = x;
+		model.rotateAngleY = y;
+		model.rotateAngleZ = z;
+	}
 }

--- a/src/main/java/openblocks/client/model/AbstractModel.java
+++ b/src/main/java/openblocks/client/model/AbstractModel.java
@@ -1,0 +1,7 @@
+package openblocks.client.model;
+
+import net.minecraft.client.model.ModelBase;
+
+public abstract class AbstractModel extends ModelBase {
+	protected static final float SCALE = 1.0f / 16.0f;
+}

--- a/src/main/java/openblocks/client/model/ModelAutoAnvil.java
+++ b/src/main/java/openblocks/client/model/ModelAutoAnvil.java
@@ -3,14 +3,12 @@ package openblocks.client.model;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 
-public class ModelAutoAnvil extends ModelBase {
+public class ModelAutoAnvil extends AbstractModel {
 	// fields
 	ModelRenderer level1;
 	ModelRenderer level2;
 	ModelRenderer level3;
 	ModelRenderer level4;
-
-	float f5 = 0.0625F;
 
 	public ModelAutoAnvil() {
 		textureWidth = 128;
@@ -42,10 +40,10 @@ public class ModelAutoAnvil extends ModelBase {
 	}
 
 	public void render() {
-		level1.render(f5);
-		level2.render(f5);
-		level3.render(f5);
-		level4.render(f5);
+		level1.render(SCALE);
+		level2.render(SCALE);
+		level3.render(SCALE);
+		level4.render(SCALE);
 	}
 
 	private static void setRotation(ModelRenderer model, float x, float y, float z) {

--- a/src/main/java/openblocks/client/model/ModelAutoAnvil.java
+++ b/src/main/java/openblocks/client/model/ModelAutoAnvil.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 
 public class ModelAutoAnvil extends AbstractModel {
@@ -44,12 +43,6 @@ public class ModelAutoAnvil extends AbstractModel {
 		level2.render(SCALE);
 		level3.render(SCALE);
 		level4.render(SCALE);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 }

--- a/src/main/java/openblocks/client/model/ModelBearTrap.java
+++ b/src/main/java/openblocks/client/model/ModelBearTrap.java
@@ -4,7 +4,7 @@ import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import openblocks.common.tileentity.TileEntityBearTrap;
 
-public class ModelBearTrap extends ModelBase {
+public class ModelBearTrap extends AbstractModel {
 
 	ModelRenderer middle;
 
@@ -142,8 +142,6 @@ public class ModelBearTrap extends ModelBase {
 	}
 
 	public void renderAll(boolean shut, int ticksSinceOpened) {
-		float f5 = 0.0625F;
-
 		float rot = 1.4F;
 
 		if (!shut) {
@@ -167,24 +165,24 @@ public class ModelBearTrap extends ModelBase {
 		rightspike3.rotateAngleZ = rot;
 		rightspike4.rotateAngleZ = rot;
 
-		middle.render(f5);
+		middle.render(SCALE);
 
-		trigger.render(f5);
-		leftnearside.render(f5);
-		lefttopside.render(f5);
-		leftfarside.render(f5);
-		leftspike2.render(f5);
-		leftspike1.render(f5);
-		leftspike3.render(f5);
-		leftspike4.render(f5);
-		leftspike5.render(f5);
+		trigger.render(SCALE);
+		leftnearside.render(SCALE);
+		lefttopside.render(SCALE);
+		leftfarside.render(SCALE);
+		leftspike2.render(SCALE);
+		leftspike1.render(SCALE);
+		leftspike3.render(SCALE);
+		leftspike4.render(SCALE);
+		leftspike5.render(SCALE);
 
-		righttopside.render(f5);
-		rightfarside.render(f5);
-		rightnearside.render(f5);
-		rightspike1.render(f5);
-		rightspike2.render(f5);
-		rightspike3.render(f5);
-		rightspike4.render(f5);
+		righttopside.render(SCALE);
+		rightfarside.render(SCALE);
+		rightnearside.render(SCALE);
+		rightspike1.render(SCALE);
+		rightspike2.render(SCALE);
+		rightspike3.render(SCALE);
+		rightspike4.render(SCALE);
 	}
 }

--- a/src/main/java/openblocks/client/model/ModelBearTrap.java
+++ b/src/main/java/openblocks/client/model/ModelBearTrap.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import openblocks.common.tileentity.TileEntityBearTrap;
 
@@ -133,12 +132,6 @@ public class ModelBearTrap extends AbstractModel {
 		trigger.setTextureSize(64, 32);
 		trigger.mirror = true;
 		setRotation(trigger, 0F, 0F, 0F);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 	public void renderAll(boolean shut, int ticksSinceOpened) {

--- a/src/main/java/openblocks/client/model/ModelCannon.java
+++ b/src/main/java/openblocks/client/model/ModelCannon.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 import openblocks.common.tileentity.TileEntityCannon;
@@ -112,12 +111,6 @@ public class ModelCannon extends AbstractModel {
 		wheel.rotateAngleX += deg30;
 		wheel.rotationPointX -= 0.01;
 		wheel.render(SCALE);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 	public void setRotationAngles(TileEntity te, float f) {}

--- a/src/main/java/openblocks/client/model/ModelCannon.java
+++ b/src/main/java/openblocks/client/model/ModelCannon.java
@@ -5,7 +5,7 @@ import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 import openblocks.common.tileentity.TileEntityCannon;
 
-public class ModelCannon extends ModelBase {
+public class ModelCannon extends AbstractModel {
 
 	private double[] keyframes = new double[] {
 			0,
@@ -64,8 +64,7 @@ public class ModelCannon extends ModelBase {
 	public void render(TileEntity te, float f) {
 
 		TileEntityCannon cannon = (TileEntityCannon)te;
-
-		float f5 = 0.0625F;
+		
 		setRotationAngles(te, f);
 
 		int elapsed = Math.min(12, cannon.getTicksSinceLastFire());
@@ -86,33 +85,33 @@ public class ModelCannon extends ModelBase {
 		body.rotateAngleX = shooter.rotateAngleX;
 
 		body.rotateAngleX = shooter.rotateAngleX;
-		body.render(f5);
-		shooter.render(f5);
-		base.render(f5);
+		body.render(SCALE);
+		shooter.render(SCALE);
+		base.render(SCALE);
 
 		float startAngleX = (float)ease;
 
 		wheel.rotateAngleZ = 0;
 		wheel.rotateAngleX = startAngleX;
 		wheel.rotationPointX = 0;
-		wheel.render(f5);
+		wheel.render(SCALE);
 		wheel.rotateAngleX += deg30;
 		wheel.rotationPointX -= 0.01;
-		wheel.render(f5);
+		wheel.render(SCALE);
 		wheel.rotateAngleX += deg30;
 		wheel.rotationPointX -= 0.01;
-		wheel.render(f5);
+		wheel.render(SCALE);
 
 		wheel.rotateAngleZ = deg180;
 		wheel.rotateAngleX = -startAngleX;
 		wheel.rotationPointX = 0;
-		wheel.render(f5);
+		wheel.render(SCALE);
 		wheel.rotateAngleX += deg30;
 		wheel.rotationPointX -= 0.01;
-		wheel.render(f5);
+		wheel.render(SCALE);
 		wheel.rotateAngleX += deg30;
 		wheel.rotationPointX -= 0.01;
-		wheel.render(f5);
+		wheel.render(SCALE);
 	}
 
 	private static void setRotation(ModelRenderer model, float x, float y, float z) {

--- a/src/main/java/openblocks/client/model/ModelCartographer.java
+++ b/src/main/java/openblocks/client/model/ModelCartographer.java
@@ -15,8 +15,7 @@ import org.lwjgl.opengl.GL11;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
-public class ModelCartographer extends ModelBase {
-	private static final float SCALE = 1.0f / 16.0f;
+public class ModelCartographer extends AbstractModel {
 	private final ModelRenderer body;
 	private final ModelRenderer base;
 

--- a/src/main/java/openblocks/client/model/ModelCartographer.java
+++ b/src/main/java/openblocks/client/model/ModelCartographer.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.client.renderer.ItemRenderer;
 import net.minecraft.client.renderer.Tessellator;

--- a/src/main/java/openblocks/client/model/ModelEgg.java
+++ b/src/main/java/openblocks/client/model/ModelEgg.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 
 public class ModelEgg extends AbstractModel {

--- a/src/main/java/openblocks/client/model/ModelEgg.java
+++ b/src/main/java/openblocks/client/model/ModelEgg.java
@@ -3,7 +3,7 @@ package openblocks.client.model;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 
-public class ModelEgg extends ModelBase {
+public class ModelEgg extends AbstractModel {
 	ModelRenderer egg;
 
 	public ModelEgg() {
@@ -32,6 +32,6 @@ public class ModelEgg extends ModelBase {
 	}
 
 	public void render() {
-		egg.render(0.0625f);
+		egg.render(SCALE);
 	}
 }

--- a/src/main/java/openblocks/client/model/ModelFan.java
+++ b/src/main/java/openblocks/client/model/ModelFan.java
@@ -4,7 +4,7 @@ import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 
-public class ModelFan extends ModelBase {
+public class ModelFan extends AbstractModel {
 
 	ModelRenderer outline1;
 	ModelRenderer outline2;
@@ -92,18 +92,17 @@ public class ModelFan extends ModelBase {
 	public void render(TileEntity te, float partialTickTime, float bladeRotation) {
 		fan.rotateAngleZ = bladeRotation;
 
-		final float scale = 1.0f / 16.0f;
-		outline1.render(scale);
-		outline2.render(scale);
-		outline3.render(scale);
-		outline4.render(scale);
-		outline5.render(scale);
-		outline6.render(scale);
-		outline7.render(scale);
-		outline8.render(scale);
-		stand.render(scale);
-		base.render(scale);
-		fan.render(scale);
+		outline1.render(SCALE);
+		outline2.render(SCALE);
+		outline3.render(SCALE);
+		outline4.render(SCALE);
+		outline5.render(SCALE);
+		outline6.render(SCALE);
+		outline7.render(SCALE);
+		outline8.render(SCALE);
+		stand.render(SCALE);
+		base.render(SCALE);
+		fan.render(SCALE);
 	}
 
 	private static void setRotation(ModelRenderer model, float x, float y, float z) {

--- a/src/main/java/openblocks/client/model/ModelFan.java
+++ b/src/main/java/openblocks/client/model/ModelFan.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 
@@ -103,12 +102,6 @@ public class ModelFan extends AbstractModel {
 		stand.render(SCALE);
 		base.render(SCALE);
 		fan.render(SCALE);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 }

--- a/src/main/java/openblocks/client/model/ModelFlag.java
+++ b/src/main/java/openblocks/client/model/ModelFlag.java
@@ -3,7 +3,7 @@ package openblocks.client.model;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 
-public class ModelFlag extends ModelBase {
+public class ModelFlag extends AbstractModel {
 	// fields
 	ModelRenderer pole;
 
@@ -20,7 +20,7 @@ public class ModelFlag extends ModelBase {
 	}
 
 	public void render(float f) {
-		pole.render(0.0625F);
+		pole.render(SCALE);
 	}
 
 	private static void setRotation(ModelRenderer model, float x, float y, float z) {

--- a/src/main/java/openblocks/client/model/ModelFlag.java
+++ b/src/main/java/openblocks/client/model/ModelFlag.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 
 public class ModelFlag extends AbstractModel {
@@ -21,12 +20,6 @@ public class ModelFlag extends AbstractModel {
 
 	public void render(float f) {
 		pole.render(SCALE);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 }

--- a/src/main/java/openblocks/client/model/ModelGrave.java
+++ b/src/main/java/openblocks/client/model/ModelGrave.java
@@ -5,7 +5,7 @@ import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 import openblocks.common.tileentity.TileEntityGrave;
 
-public class ModelGrave extends ModelBase {
+public class ModelGrave extends AbstractModel {
 
 	ModelRenderer stone;
 	ModelRenderer floor;
@@ -30,15 +30,14 @@ public class ModelGrave extends ModelBase {
 
 	public void render(TileEntity te, float f) {
 		if (!(te instanceof TileEntityGrave)) return;
-		float f5 = 0.0625F;
 		setRotationAngles(te, f);
 		if (((TileEntityGrave)te).isOnSoil()) {
 			stone.setRotationPoint(0F, 15.5F, 6F);
-			floor.render(f5);
+			floor.render(SCALE);
 		} else {
 			stone.setRotationPoint(0F, 16.5F, 6F);
 		}
-		stone.render(f5);
+		stone.render(SCALE);
 	}
 
 	private static void setRotation(ModelRenderer model, float x, float y, float z) {

--- a/src/main/java/openblocks/client/model/ModelGrave.java
+++ b/src/main/java/openblocks/client/model/ModelGrave.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 import openblocks.common.tileentity.TileEntityGrave;
@@ -38,12 +37,6 @@ public class ModelGrave extends AbstractModel {
 			stone.setRotationPoint(0F, 16.5F, 6F);
 		}
 		stone.render(SCALE);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 	/**

--- a/src/main/java/openblocks/client/model/ModelPaintMixer.java
+++ b/src/main/java/openblocks/client/model/ModelPaintMixer.java
@@ -4,7 +4,7 @@ import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 
-public class ModelPaintMixer extends ModelBase
+public class ModelPaintMixer extends AbstractModel
 {
 	// fields
 	ModelRenderer controls;
@@ -71,13 +71,12 @@ public class ModelPaintMixer extends ModelBase
 	}
 
 	public void render(TileEntity te, float f) {
-		float f5 = 0.0625F;
-		controls.render(f5);
-		right.render(f5);
-		left.render(f5);
-		back.render(f5);
-		top.render(f5);
-		bottom.render(f5);
-		bottom2.render(f5);
+		controls.render(SCALE);
+		right.render(SCALE);
+		left.render(SCALE);
+		back.render(SCALE);
+		top.render(SCALE);
+		bottom.render(SCALE);
+		bottom2.render(SCALE);
 	}
 }

--- a/src/main/java/openblocks/client/model/ModelPaintMixer.java
+++ b/src/main/java/openblocks/client/model/ModelPaintMixer.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 
@@ -62,12 +61,6 @@ public class ModelPaintMixer extends AbstractModel
 		bottom2.setTextureSize(64, 64);
 		bottom2.mirror = true;
 		setRotation(bottom2, 0F, 0F, 0F);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 	public void render(TileEntity te, float f) {

--- a/src/main/java/openblocks/client/model/ModelPiggy.java
+++ b/src/main/java/openblocks/client/model/ModelPiggy.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import openblocks.common.tileentity.TileEntityDonationStation;
 
@@ -95,11 +94,5 @@ public class ModelPiggy extends AbstractModel {
 		leg1.render(SCALE);
 		leg3.render(SCALE);
 		tail.render(SCALE);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 }

--- a/src/main/java/openblocks/client/model/ModelPiggy.java
+++ b/src/main/java/openblocks/client/model/ModelPiggy.java
@@ -4,7 +4,7 @@ import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import openblocks.common.tileentity.TileEntityDonationStation;
 
-public class ModelPiggy extends ModelBase {
+public class ModelPiggy extends AbstractModel {
 	// fields
 	ModelRenderer body;
 	ModelRenderer head;
@@ -85,17 +85,16 @@ public class ModelPiggy extends ModelBase {
 	}
 
 	public void render(TileEntityDonationStation station, float f) {
-		float f5 = 0.0625F;
-		body.render(f5);
-		head.render(f5);
-		snout.render(f5);
-		ear2.render(f5);
-		ear1.render(f5);
-		leg4.render(f5);
-		leg2.render(f5);
-		leg1.render(f5);
-		leg3.render(f5);
-		tail.render(f5);
+		body.render(SCALE);
+		head.render(SCALE);
+		snout.render(SCALE);
+		ear2.render(SCALE);
+		ear1.render(SCALE);
+		leg4.render(SCALE);
+		leg2.render(SCALE);
+		leg1.render(SCALE);
+		leg3.render(SCALE);
+		tail.render(SCALE);
 	}
 
 	private static void setRotation(ModelRenderer model, float x, float y, float z) {

--- a/src/main/java/openblocks/client/model/ModelProjector.java
+++ b/src/main/java/openblocks/client/model/ModelProjector.java
@@ -3,9 +3,8 @@ package openblocks.client.model;
 import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 
-public class ModelProjector extends ModelBase {
+public class ModelProjector extends AbstractModel {
 
-	private static final float SCALE = 1.0f / 16.0f;
 	private static final float DEG_45 = (float)Math.toRadians(45);
 	// private static final float DEG_135 = (float)Math.toRadians(135);
 

--- a/src/main/java/openblocks/client/model/ModelProjector.java
+++ b/src/main/java/openblocks/client/model/ModelProjector.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 
 public class ModelProjector extends AbstractModel {

--- a/src/main/java/openblocks/client/model/ModelSprinkler.java
+++ b/src/main/java/openblocks/client/model/ModelSprinkler.java
@@ -5,7 +5,7 @@ import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 import openblocks.common.tileentity.TileEntitySprinkler;
 
-public class ModelSprinkler extends ModelBase {
+public class ModelSprinkler extends AbstractModel {
 
 	ModelRenderer side1;
 	ModelRenderer side2;
@@ -51,14 +51,13 @@ public class ModelSprinkler extends ModelBase {
 
 	public void render(TileEntitySprinkler sprinkler, float f) {
 
-		float f5 = 0.0625F;
 		setRotationAngles(sprinkler, f);
-		side1.render(f5);
-		side2.render(f5);
-		end1.render(f5);
-		end2.render(f5);
+		side1.render(SCALE);
+		side2.render(SCALE);
+		end1.render(SCALE);
+		end2.render(SCALE);
 
-		sprayer.render(f5);
+		sprayer.render(SCALE);
 	}
 
 	private static void setRotation(ModelRenderer model, float x, float y, float z) {

--- a/src/main/java/openblocks/client/model/ModelSprinkler.java
+++ b/src/main/java/openblocks/client/model/ModelSprinkler.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 import openblocks.common.tileentity.TileEntitySprinkler;
@@ -58,12 +57,6 @@ public class ModelSprinkler extends AbstractModel {
 		end2.render(SCALE);
 
 		sprayer.render(SCALE);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 	/**

--- a/src/main/java/openblocks/client/model/ModelTarget.java
+++ b/src/main/java/openblocks/client/model/ModelTarget.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 import openblocks.common.tileentity.TileEntityTarget;
@@ -41,12 +40,6 @@ public class ModelTarget extends AbstractModel {
 		stand1.render(SCALE);
 		target.render(SCALE);
 		stand2.render(SCALE);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 	/**

--- a/src/main/java/openblocks/client/model/ModelTarget.java
+++ b/src/main/java/openblocks/client/model/ModelTarget.java
@@ -5,7 +5,7 @@ import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 import openblocks.common.tileentity.TileEntityTarget;
 
-public class ModelTarget extends ModelBase {
+public class ModelTarget extends AbstractModel {
 
 	ModelRenderer stand1;
 	ModelRenderer target;
@@ -37,11 +37,10 @@ public class ModelTarget extends ModelBase {
 
 	public void render(TileEntity te, float f) {
 
-		float f5 = 0.0625F;
 		setRotationAngles(te, f);
-		stand1.render(f5);
-		target.render(f5);
-		stand2.render(f5);
+		stand1.render(SCALE);
+		target.render(SCALE);
+		stand2.render(SCALE);
 	}
 
 	private static void setRotation(ModelRenderer model, float x, float y, float z) {

--- a/src/main/java/openblocks/client/model/ModelVacuumHopper.java
+++ b/src/main/java/openblocks/client/model/ModelVacuumHopper.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraftforge.common.util.ForgeDirection;
 import openblocks.common.tileentity.TileEntityVacuumHopper;
@@ -82,12 +81,6 @@ public class ModelVacuumHopper extends AbstractModel {
 		renderValve(itemOutputs, xpOutputs, ForgeDirection.NORTH, (float)Math.toRadians(-90), 0, SCALE);
 		renderValve(itemOutputs, xpOutputs, ForgeDirection.SOUTH, (float)Math.toRadians(90), 0, SCALE);
 
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 }

--- a/src/main/java/openblocks/client/model/ModelVacuumHopper.java
+++ b/src/main/java/openblocks/client/model/ModelVacuumHopper.java
@@ -6,7 +6,7 @@ import net.minecraftforge.common.util.ForgeDirection;
 import openblocks.common.tileentity.TileEntityVacuumHopper;
 import openmods.utils.bitmap.IReadableBitMap;
 
-public class ModelVacuumHopper extends ModelBase {
+public class ModelVacuumHopper extends AbstractModel {
 
 	ModelRenderer middle;
 	ModelRenderer outputItems;
@@ -53,7 +53,7 @@ public class ModelVacuumHopper extends ModelBase {
 		setRotation(outputItems, 0F, 0F, 0F);
 	}
 
-	private void renderValve(IReadableBitMap<ForgeDirection> itemOutputs, IReadableBitMap<ForgeDirection> xpOutputs, ForgeDirection direction, float rotX, float rotZ, float f5) {
+	private void renderValve(IReadableBitMap<ForgeDirection> itemOutputs, IReadableBitMap<ForgeDirection> xpOutputs, ForgeDirection direction, float rotX, float rotZ, float SCALE) {
 		boolean items = itemOutputs.get(direction);
 		boolean xp = xpOutputs.get(direction);
 
@@ -61,8 +61,8 @@ public class ModelVacuumHopper extends ModelBase {
 			ModelRenderer valve = items && xp? outputBoth : items? outputItems : outputXP;
 			output2.rotateAngleX = valve.rotateAngleX = rotX;
 			output2.rotateAngleZ = valve.rotateAngleZ = rotZ;
-			output2.render(f5);
-			valve.render(f5);
+			output2.render(SCALE);
+			valve.render(SCALE);
 		}
 	}
 
@@ -71,17 +71,16 @@ public class ModelVacuumHopper extends ModelBase {
 	 */
 	public void render(TileEntityVacuumHopper hopper, float f) {
 
-		float f5 = 0.0625F;
-		middle.render(f5);
+		middle.render(SCALE);
 		final IReadableBitMap<ForgeDirection> itemOutputs = hopper.getReadableItemOutputs();
 		final IReadableBitMap<ForgeDirection> xpOutputs = hopper.getReadableXpOutputs();
 
-		renderValve(itemOutputs, xpOutputs, ForgeDirection.UP, 0, 0, f5);
-		renderValve(itemOutputs, xpOutputs, ForgeDirection.DOWN, (float)Math.toRadians(180), 0, f5);
-		renderValve(itemOutputs, xpOutputs, ForgeDirection.EAST, 0, (float)Math.toRadians(90), f5);
-		renderValve(itemOutputs, xpOutputs, ForgeDirection.WEST, 0, (float)Math.toRadians(-90), f5);
-		renderValve(itemOutputs, xpOutputs, ForgeDirection.NORTH, (float)Math.toRadians(-90), 0, f5);
-		renderValve(itemOutputs, xpOutputs, ForgeDirection.SOUTH, (float)Math.toRadians(90), 0, f5);
+		renderValve(itemOutputs, xpOutputs, ForgeDirection.UP, 0, 0, SCALE);
+		renderValve(itemOutputs, xpOutputs, ForgeDirection.DOWN, (float)Math.toRadians(180), 0, SCALE);
+		renderValve(itemOutputs, xpOutputs, ForgeDirection.EAST, 0, (float)Math.toRadians(90), SCALE);
+		renderValve(itemOutputs, xpOutputs, ForgeDirection.WEST, 0, (float)Math.toRadians(-90), SCALE);
+		renderValve(itemOutputs, xpOutputs, ForgeDirection.NORTH, (float)Math.toRadians(-90), 0, SCALE);
+		renderValve(itemOutputs, xpOutputs, ForgeDirection.SOUTH, (float)Math.toRadians(90), 0, SCALE);
 
 	}
 

--- a/src/main/java/openblocks/client/model/ModelVillage.java
+++ b/src/main/java/openblocks/client/model/ModelVillage.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 
@@ -40,12 +39,6 @@ public class ModelVillage extends AbstractModel {
 		main.render(SCALE);
 		step.render(SCALE);
 		roof.render(SCALE);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 	/**

--- a/src/main/java/openblocks/client/model/ModelVillage.java
+++ b/src/main/java/openblocks/client/model/ModelVillage.java
@@ -4,7 +4,7 @@ import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 
-public class ModelVillage extends ModelBase {
+public class ModelVillage extends AbstractModel {
 	// fields
 	ModelRenderer main;
 	ModelRenderer step;
@@ -36,11 +36,10 @@ public class ModelVillage extends ModelBase {
 
 	public void render(TileEntity te, float f) {
 
-		float f5 = 0.0625F;
 		setRotationAngles(te, f);
-		main.render(f5);
-		step.render(f5);
-		roof.render(f5);
+		main.render(SCALE);
+		step.render(SCALE);
+		roof.render(SCALE);
 	}
 
 	private static void setRotation(ModelRenderer model, float x, float y, float z) {

--- a/src/main/java/openblocks/client/model/ModelXPShower.java
+++ b/src/main/java/openblocks/client/model/ModelXPShower.java
@@ -4,7 +4,7 @@ import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 
-public class ModelXPShower extends ModelBase
+public class ModelXPShower extends AbstractModel
 {
 	ModelRenderer end;
 	ModelRenderer main;
@@ -30,10 +30,9 @@ public class ModelXPShower extends ModelBase
 
 	public void render(TileEntity te, float f) {
 
-		float f5 = 0.0625F;
 		setRotationAngles(te, f);
-		main.render(f5);
-		end.render(f5);
+		main.render(SCALE);
+		end.render(SCALE);
 	}
 
 	private static void setRotation(ModelRenderer model, float x, float y, float z) {

--- a/src/main/java/openblocks/client/model/ModelXPShower.java
+++ b/src/main/java/openblocks/client/model/ModelXPShower.java
@@ -1,6 +1,5 @@
 package openblocks.client.model;
 
-import net.minecraft.client.model.ModelBase;
 import net.minecraft.client.model.ModelRenderer;
 import net.minecraft.tileentity.TileEntity;
 
@@ -33,12 +32,6 @@ public class ModelXPShower extends AbstractModel
 		setRotationAngles(te, f);
 		main.render(SCALE);
 		end.render(SCALE);
-	}
-
-	private static void setRotation(ModelRenderer model, float x, float y, float z) {
-		model.rotateAngleX = x;
-		model.rotateAngleY = y;
-		model.rotateAngleZ = z;
 	}
 
 	/**


### PR DESCRIPTION
Having the float f5 made every time render() is called causes some meaningless overhead.

Also moved the setRotation() to abstract parent to remove duplication