### PR TITLE
added config option to require grave in inventory and consume it

### DIFF
--- a/src/main/java/openblocks/Config.java
+++ b/src/main/java/openblocks/Config.java
@@ -195,6 +195,10 @@ public class Config {
 	public static double skeletonSpawnRate = 0.002;
 
 	@OnLineModifiable
+	@ConfigProperty(category = "graves", name = "requiresGraveInInv", comment = "Require gravestone to be in a player's inventory (it is consumed)")
+	public static boolean requiresGraveInInv = false;
+
+	@OnLineModifiable
 	@ConfigProperty(category = "graves", name = "specialActionFrequency", comment = "Frequency of special action on grave digging, 0..1")
 	public static double graveSpecialAction = 0.03;
 


### PR DESCRIPTION
I added this feature to strike a balance between my players wanting graves, and me wanting death to have consequences.  It worked out pretty well.  I added the grave recipe using minetweaker.  I did not add a recipe to the mod, partly because I wasn't sure if people would like it, and mainly because I didn't know how.  Either way, nothing is changed by default (the new config option defaults to off), and even without a recipe, this might be handy for server admins who want to hand out a limited allowance of graves.

My grave recipe is:
DPD
SCS
SCS
(diamond, (ender) pearl, stone, chest)