### PR TITLE
Update mcmod.info to 1.7.X/1.8 format

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,20 +1,33 @@
-[
 {
-  "modid" : "OpenBlocks",
-  "name" : "OpenBlocks",
-  "version" : "${version}",
-  "url" : "http://www.openperipheral.info",
-  "credits" : "",
-  "authors": [
-    "Mikee",
-    "NeverCast",
-    "boq",
-    "Lyqyd"
-  ],
-  "description": "All the things you never thought you will ever need",
-  "logoFile" : "",
-  "updateUrl" : "",
-  "parent" : "",
-  "screenshots": [
+  "modListVersion": "2",
+  "modList":
+  [
+    {
+      "modid": "OpenBlocks",
+      "name": "OpenBlocks",
+      "description": "All the things you never thought you will ever need",
+      "version": "${version}",
+      "mcversion": "${MCVersion}",
+      "url": "http://openmods.info/",
+      "updateUrl": "",
+      "authorList": [
+        "Mikee",
+        "NeverCast",
+        "boq",
+        "Lyqyd"
+      ],
+      "credits": "",
+      "logoFile": "",
+      "screenshots": [
+      ],
+      "parent": "",
+      "requiredMods": [
+      ],
+      "dependencies": [
+      ],
+      "dependants": [
+      ],
+      "useDependencyInformation": "false"
+    }
   ]
-}]
+}


### PR DESCRIPTION
This PR updates the `mcmod.info` file to the new format used from Forge 1.7.2 onwards.

The only major difference is the use of the `authorList` tag instead of `authors`, but I thought that I could update to the example shown on [FML's wiki](https://github.com/MinecraftForge/FML/wiki/FML-mod-information-file#Example) for consistency.

This also brings a minor bug fix: using the previous format, the Donation Station GUI [would not show the mod's authors](http://image.prntscr.com/image/86d9cd95208a4089bd42ebcd02a6818c.png) when an item was placed in the slot, while [it does](https://raw.githubusercontent.com/OpenMods/OpenMods-IGW/master/src/main/resources/assets/openmods-igw/wiki/worldwide/images/block/donationStation/gallery_ob.png) with the new format.