### PR TITLE
Optional thermal lifts for the hangglider (incl. opt. acoustic vario) + Lag fix

### DIFF
--- a/src/main/java/openblocks/Config.java
+++ b/src/main/java/openblocks/Config.java
@@ -380,6 +380,10 @@ public class Config {
 	@ConfigProperty(category = "devnull", name = "sneakClickToGui", comment = "If true, /dev/null will require sneaking in addition to clicking air to open gui")
 	public static boolean devNullSneakGui = true;
 
+	@OnLineModifiable
+	@ConfigProperty(category = "hangglider", name = "enableThermal", comment = "Enable a whole new level of hanggliding experience through thermal lift. See keybindings for acoustic vario controls")
+	public static boolean hanggliderEnableThermal = true;
+
 	public static void register() {
 		@SuppressWarnings("unchecked")
 		final List<IRecipe> recipeList = CraftingManager.getInstance().getRecipeList();

--- a/src/main/java/openblocks/client/GliderPlayerRenderHandler.java
+++ b/src/main/java/openblocks/client/GliderPlayerRenderHandler.java
@@ -11,7 +11,7 @@ public class GliderPlayerRenderHandler {
 	@SubscribeEvent
 	public void onPlayerBodyRender(PlayerBodyRenderEvent evt) {
 		final AbstractClientPlayer player = evt.player;
-		if (!EntityHangGlider.isGliderDeployed(player)) {
+		if (EntityHangGlider.isGliderDeployed(player)) {
 			player.limbSwing = 0f;
 			player.prevLimbSwingAmount = 0f;
 			player.limbSwingAmount = 0f;

--- a/src/main/java/openblocks/client/bindings/KeyInputHandler.java
+++ b/src/main/java/openblocks/client/bindings/KeyInputHandler.java
@@ -7,19 +7,34 @@ import cpw.mods.fml.common.gameevent.InputEvent;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
 import openblocks.Config;
+import openblocks.common.entity.EntityHangGlider;
 import openblocks.events.PlayerActionEvent;
 import org.lwjgl.input.Keyboard;
 
 public class KeyInputHandler {
 
 	private KeyBinding brickBinding;
+	private KeyBinding varioSwitchBinding;
+	private KeyBinding varioVolUpBinding;
+	private KeyBinding varioVolDownBinding;
 
 	private boolean brickKeyPressed;
+	private boolean varioSwitchKeyPressed;
+	private boolean varioVolUpKeyPressed;
+	private boolean varioVolDownKeyPressed;
 
 	public void setup() {
 		if (!Config.soSerious) {
 			brickBinding = new KeyBinding("openblocks.keybind.drop_brick", Keyboard.KEY_B, "openblocks.keybind.category");
 			ClientRegistry.registerKeyBinding(brickBinding);
+		}
+		if (Config.hanggliderEnableThermal) {
+			varioSwitchBinding = new KeyBinding("openblocks.keybind.vario_switch", Keyboard.KEY_V, "openblocks.keybind.category");
+			varioVolUpBinding = new KeyBinding("openblocks.keybind.vario_vol_up", Keyboard.KEY_I, "openblocks.keybind.category");
+			varioVolDownBinding = new KeyBinding("openblocks.keybind.vario_vol_down", Keyboard.KEY_K, "openblocks.keybind.category");
+			ClientRegistry.registerKeyBinding(varioSwitchBinding);
+			ClientRegistry.registerKeyBinding(varioVolUpBinding);
+			ClientRegistry.registerKeyBinding(varioVolDownBinding);
 		}
 		FMLCommonHandler.instance().bus().register(this);
 	}
@@ -36,6 +51,24 @@ public class KeyInputHandler {
 				brickKeyPressed = true;
 			}
 		} else brickKeyPressed = false;
+		if (varioSwitchBinding != null && varioSwitchBinding.isPressed()) {
+			if (!varioSwitchKeyPressed) {
+				EntityHangGlider.toggleVario();
+				varioSwitchKeyPressed = true;
+			}
+		} else varioSwitchKeyPressed = false;
+		if (varioVolUpBinding != null && varioVolUpBinding.isPressed()) {
+			if (!varioVolUpKeyPressed) {
+				EntityHangGlider.incVarioVol();
+				varioVolUpKeyPressed = true;
+			}
+		} else varioVolUpKeyPressed = false;
+		if (varioVolDownBinding != null && varioVolDownBinding.isPressed()) {
+			if (!varioVolDownKeyPressed) {
+				EntityHangGlider.decVarioVol();
+				varioVolDownKeyPressed = true;
+			}
+		} else varioVolDownKeyPressed = false;
 	}
 
 }

--- a/src/main/java/openblocks/client/renderer/entity/EntityHangGliderRenderer.java
+++ b/src/main/java/openblocks/client/renderer/entity/EntityHangGliderRenderer.java
@@ -52,7 +52,7 @@ public class EntityHangGliderRenderer extends Render {
 		final boolean isFpp = minecraft.gameSettings.thirdPersonView == 0;
 		final boolean isDeployed = glider.isDeployed();
 
-		if (isLocalPlayer && isFpp && isDeployed) return;
+		if (isLocalPlayer && isFpp && !isDeployed) return;
 
 		final float rotation = interpolateRotation(glider.prevRotationYaw, glider.rotationYaw, f1);
 
@@ -62,7 +62,7 @@ public class EntityHangGliderRenderer extends Render {
 		GL11.glRotatef(180.0F - rotation, 0.0F, 1.0F, 0.0F);
 
 		if (isLocalPlayer) {
-			if (isDeployed) {
+			if (!isDeployed) {
 				// move up and closer to back
 				GL11.glTranslated(0, -0.2, +0.3);
 			} else {
@@ -75,7 +75,7 @@ public class EntityHangGliderRenderer extends Render {
 				}
 			}
 		} else {
-			if (isDeployed) {
+			if (!isDeployed) {
 				// move up little bit (other player center is lower)
 				GL11.glTranslated(0, +0.2, +0.3);
 			} else {
@@ -84,7 +84,7 @@ public class EntityHangGliderRenderer extends Render {
 			}
 		}
 
-		if (isDeployed) {
+		if (!isDeployed) {
 			GL11.glRotatef(ONGROUND_ROTATION, 1, 0, 0);
 			GL11.glScalef(0.4f, 1f, 0.4f);
 		}

--- a/src/main/java/openblocks/common/BeepGenerator.java
+++ b/src/main/java/openblocks/common/BeepGenerator.java
@@ -1,0 +1,215 @@
+package openblocks.common;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.SourceDataLine;
+
+public class BeepGenerator {
+
+	private static final int SAMPLE_RATE = 128 * 1024;
+	private static final int MIN_BUFFER_AVAILABLE = (int) (SAMPLE_RATE * 64 / 1000);
+	private static final int TIMEOUT_SECONDS = 1;
+
+	private static byte volume = 8;
+
+	public static byte getVolume() {
+		return volume;
+	}
+
+	public static void setVolume(byte volume) {
+		BeepGenerator.volume = volume;
+	}
+
+	private byte[] buffer;
+	private int bufferSize;
+	private boolean currentlyBeeping;
+	private boolean running;
+
+	private double toneFrequency;
+	private double lastToneFrequency;
+	private double beepFrequency;
+	private int samplesSinceLastBeepChange;
+	private int timeout;
+
+	private SourceDataLine line;
+
+	private Thread writer;
+
+	public BeepGenerator() {
+		running = false;
+	}
+
+	public void start() {
+		running = true;
+		timeout = TIMEOUT_SECONDS * 10;
+
+		AudioFormat af = new AudioFormat(SAMPLE_RATE, 8, 1, true, true);
+		try {
+			this.line = AudioSystem.getSourceDataLine(af);
+			this.line.open(af, SAMPLE_RATE);
+		} catch (LineUnavailableException e) {
+			e.printStackTrace();
+		}
+		bufferSize = this.line.getBufferSize();
+
+		startWriter();
+		startTimeout();
+	}
+
+	public void stop() {
+		timeout = 0;
+		setToneFrequency(0d);
+		setBeepFrequency(0d);
+	}
+
+	public void keepAlive() {
+		timeout = TIMEOUT_SECONDS * 10;
+	}
+
+	public boolean isRunning() {
+		return running;
+	}
+
+	private void startWriter() {
+		new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+				long t;
+
+				writeSample();
+				writeSample();
+
+				BeepGenerator.this.line.start();
+
+				int kill = 5;
+
+				while (BeepGenerator.this.running) {
+
+					writeSample();
+
+					// Calculate sleep in ms from buffer-surplus
+					int bufferAvailable = bufferSize - BeepGenerator.this.line.available();
+					int ms = (int) ((double) (bufferAvailable - MIN_BUFFER_AVAILABLE) / ((double) (SAMPLE_RATE) / 1000d));
+
+					if (ms <= 8)
+						continue;
+
+					// Fixes a weird bug (BeepGenerator.this.line.available() returning 0)
+					if (bufferAvailable == bufferSize) {
+						BeepGenerator.this.line.stop();
+						while (bufferAvailable == bufferSize || bufferAvailable <= MIN_BUFFER_AVAILABLE) {
+							writeSample();
+							bufferAvailable = bufferSize - BeepGenerator.this.line.available();
+						}
+						BeepGenerator.this.line.start();
+						continue;
+					}
+
+					if (ms < 100)
+						kill = 5;
+
+					if (kill == 0) {
+						stop();
+					} else {
+						kill--;
+					}
+
+					try {
+						Thread.sleep(ms);
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
+
+				}
+				BeepGenerator.this.line.close();
+			}
+		}).start();
+	}
+
+	private void startTimeout() {
+		new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+				while (BeepGenerator.this.running) {
+					BeepGenerator.this.timeout--;
+					try {
+						Thread.sleep(100);
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
+					if (BeepGenerator.this.timeout <= 0)
+						BeepGenerator.this.running = false;
+				}
+			}
+		}).start();
+	}
+
+	private void writeSample() {
+		if (this.lastToneFrequency == 0d || this.getToneFrequency() == 0d)
+			this.lastToneFrequency = this.getToneFrequency();
+		else if (this.lastToneFrequency < this.getToneFrequency())
+			this.lastToneFrequency += Math.min(5d, this.getToneFrequency() - this.lastToneFrequency);
+		else if (this.lastToneFrequency > this.getToneFrequency())
+			this.lastToneFrequency -= Math.min(5d, this.lastToneFrequency - this.getToneFrequency());
+
+		BeepGenerator.this.generateSample(this.lastToneFrequency);
+		line.write(BeepGenerator.this.buffer, 0, this.buffer.length);
+	}
+
+	private void generateSample(double frequency) {
+
+		final int samples = (int) (SAMPLE_RATE * 16 / 1000);
+
+		if (frequency == 0.0) {
+			this.buffer = new byte[samples];
+			return;
+		}
+
+		double sinLength = (SAMPLE_RATE/frequency);
+
+		int sinSmooth = (int) (sinLength - (int)(samples % sinLength));
+
+		this.buffer = new byte[samples + sinSmooth];
+
+		final int samplesPerBeep;
+		byte volume;
+		if (getBeepFrequency() > 0) {
+			samplesPerBeep = (int) ((double) SAMPLE_RATE / getBeepFrequency());
+			volume = (byte) (this.currentlyBeeping ? this.volume : 0);
+		} else {
+			samplesPerBeep = 0;
+			volume = this.volume;
+			this.currentlyBeeping = true;
+		}
+
+		for (int i = 0; i < this.buffer.length; i++) {
+			this.buffer[i] = (byte) (Math.sin((2.0 * Math.PI * i) / sinLength) * volume);
+			samplesSinceLastBeepChange++;
+			if (samplesPerBeep > 0 && samplesSinceLastBeepChange >= samplesPerBeep) {
+				this.currentlyBeeping = !this.currentlyBeeping;
+				volume = (this.currentlyBeeping ? this.volume : 0);
+				samplesSinceLastBeepChange = 0;
+			}
+		}
+	}
+
+	public double getToneFrequency() {
+		return toneFrequency;
+	}
+
+	public void setToneFrequency(double frequency) {
+		this.toneFrequency = frequency;
+	}
+
+	public double getBeepFrequency() {
+		return beepFrequency;
+	}
+
+	public void setBeepFrequency(double beepFrequency) {
+		this.beepFrequency = beepFrequency;
+	}
+
+}

--- a/src/main/java/openblocks/common/PerlinNoiseGenerator.java
+++ b/src/main/java/openblocks/common/PerlinNoiseGenerator.java
@@ -1,0 +1,635 @@
+package openblocks.common;
+
+import java.util.Random;
+
+
+/*****************************************************************************
+ *						  J3D.org Copyright (c) 2000
+ *								 Java Source
+ *
+ * This source is licensed under the GNU LGPL v2.1
+ * Please read http://www.gnu.org/copyleft/lgpl.html for more information
+ *
+ * This software comes with the standard NO WARRANTY disclaimer for any
+ * purpose. Use it at your own risk. If there's a problem you get to fix it.
+ *
+ ****************************************************************************/
+
+
+/**
+ * Computes Perlin Noise for three dimensions.
+ * <p>
+ *
+ * The result is a continuous function that interpolates a smooth path
+ * along a series random points. The function is consitent, so given
+ * the same parameters, it will always return the same value. The smoothing
+ * function is based on the Improving Noise paper presented at Siggraph 2002.
+ * <p>
+ * Computing noise for one and two dimensions can make use of the 3D problem
+ * space by just setting the un-needed dimensions to a fixed value.
+ *
+ * @author Justin Couch
+ * @version $Revision: 1.4 $
+ */
+public class PerlinNoiseGenerator
+{
+	// Constants for setting up the Perlin-1 noise functions
+	private static final int B = 0x1000;
+	private static final int BM = 0xff;
+
+	private static final int N = 0x1000;
+	private static final int NP = 12;	/* 2^N */
+	private static final int NM = 0xfff;
+
+	/** Default seed to use for the random number generation */
+	private static final int DEFAULT_SEED = 100;
+
+	/** Default sample size to work with */
+	private static final int DEFAULT_SAMPLE_SIZE = 256;
+
+	/** The log of 1/2 constant. Used Everywhere */
+	private static final float LOG_HALF = (float)Math.log(0.5);
+
+	/** Permutation array for the improved noise function */
+	private int[] p_imp;
+
+	/** P array for perline 1 noise */
+	private int[] p;
+	private float[][] g3;
+	private float[][] g2;
+	private float[] g1;
+
+
+	/**
+	 * Create a new noise creator with the default seed value
+	 */
+	public PerlinNoiseGenerator()
+	{
+		this(DEFAULT_SEED);
+	}
+
+	/**
+	 * Create a new noise creator with the given seed value for the randomness
+	 *
+	 * @param seed The seed value to use
+	 */
+	public PerlinNoiseGenerator(int seed)
+	{
+		p_imp = new int[DEFAULT_SAMPLE_SIZE << 1];
+
+		int i, j, k;
+		Random rand = new Random(seed);
+
+		// Calculate the table of psuedo-random coefficients.
+		for(i = 0; i < DEFAULT_SAMPLE_SIZE; i++)
+			p_imp[i] = i;
+
+		// generate the psuedo-random permutation table.
+		while(--i > 0)
+		{
+			k = p_imp[i];
+			j = (int)(rand.nextLong() & DEFAULT_SAMPLE_SIZE);
+			p_imp[i] = p_imp[j];
+			p_imp[j] = k;
+		}
+
+		initPerlin1();
+	}
+
+	/**
+	 * Computes noise function for three dimensions at the point (x,y,z).
+	 *
+	 * @param x x dimension parameter
+	 * @param y y dimension parameter
+	 * @param z z dimension parameter
+	 * @return the noise value at the point (x, y, z)
+	 */
+	public double improvedNoise(double x, double y, double z)
+	{
+		// Constraint the point to a unit cube
+		int uc_x = (int)Math.floor(x) & 255;
+		int uc_y = (int)Math.floor(y) & 255;
+		int uc_z = (int)Math.floor(z) & 255;
+
+		// Relative location of the point in the unit cube
+		double xo = x - Math.floor(x);
+		double yo = y - Math.floor(y);
+		double zo = z - Math.floor(z);
+
+		// Fade curves for x, y and z
+		double u = fade(xo);
+		double v = fade(yo);
+		double w = fade(zo);
+
+		// Generate a hash for each coordinate to find out where in the cube
+		// it lies.
+		int a =  p_imp[uc_x] + uc_y;
+		int aa = p_imp[a] + uc_z;
+		int ab = p_imp[a + 1] + uc_z;
+
+		int b =  p_imp[uc_x + 1] + uc_y;
+		int ba = p_imp[b] + uc_z;
+		int bb = p_imp[b + 1] + uc_z;
+
+		// blend results from the 8 corners based on the noise function
+		double c1 = grad(p_imp[aa], xo, yo, zo);
+		double c2 = grad(p_imp[ba], xo - 1, yo, zo);
+		double c3 = grad(p_imp[ab], xo, yo - 1, zo);
+		double c4 = grad(p_imp[bb], xo - 1, yo - 1, zo);
+		double c5 = grad(p_imp[aa + 1], xo, yo, zo - 1);
+		double c6 = grad(p_imp[ba + 1], xo - 1, yo, zo - 1);
+		double c7 = grad(p_imp[ab + 1], xo, yo - 1, zo - 1);
+		double c8 = grad(p_imp[bb + 1], xo - 1, yo - 1, zo - 1);
+
+		return lerp(w, lerp(v, lerp(u, c1, c2), lerp(u, c3, c4)),
+					   lerp(v, lerp(u, c5, c6), lerp(u, c7, c8)));
+	}
+
+	/**
+	 * 1-D noise generation function using the original perlin algorithm.
+	 *
+	 * @param x Seed for the noise function
+	 * @return The noisy output
+	 */
+	public float noise1(float x)
+	{
+		float t = x + N;
+		int bx0 = ((int) t) & BM;
+		int bx1 = (bx0 + 1) & BM;
+		float rx0 = t - (int) t;
+		float rx1 = rx0 - 1;
+
+		float sx = sCurve(rx0);
+
+		float u = rx0 * g1[p[bx0]];
+		float v = rx1 * g1[p[bx1]];
+
+		return lerp(sx, u, v);
+	}
+
+	/**
+	 * Create noise in a 2D space using the orignal perlin noise algorithm.
+	 *
+	 * @param x The X coordinate of the location to sample
+	 * @param y The Y coordinate of the location to sample
+	 * @return A noisy value at the given position
+	 */
+	public float noise2(float x, float y)
+	{
+		float t = x + N;
+		int bx0 = ((int)t) & BM;
+		int bx1 = (bx0 + 1) & BM;
+		float rx0 = t - (int)t;
+		float rx1 = rx0 - 1;
+
+		t = y + N;
+		int by0 = ((int)t) & BM;
+		int by1 = (by0 + 1) & BM;
+		float ry0 = t - (int)t;
+		float ry1 = ry0 - 1;
+
+		int i = p[bx0];
+		int j = p[bx1];
+
+		int b00 = p[i + by0];
+		int b10 = p[j + by0];
+		int b01 = p[i + by1];
+		int b11 = p[j + by1];
+
+		float sx = sCurve(rx0);
+		float sy = sCurve(ry0);
+
+		float[] q = g2[b00];
+		float u = rx0 * q[0] + ry0 * q[1];
+		q = g2[b10];
+		float v = rx1 * q[0] + ry0 * q[1];
+		float a = lerp(sx, u, v);
+
+		q = g2[b01];
+		u = rx0 * q[0] + ry1 * q[1];
+		q = g2[b11];
+		v = rx1 * q[0] + ry1 * q[1];
+		float b = lerp(sx, u, v);
+
+		return lerp(sy, a, b);
+	}
+
+	/**
+	 * Create noise in a 3D space using the orignal perlin noise algorithm.
+	 *
+	 * @param x The X coordinate of the location to sample
+	 * @param y The Y coordinate of the location to sample
+	 * @param z The Z coordinate of the location to sample
+	 * @return A noisy value at the given position
+	 */
+	public float noise3(float x, float y, float z)
+	{
+		float t = x + (float)N;
+		int bx0 = ((int)t) & BM;
+		int bx1 = (bx0 + 1) & BM;
+		float rx0 = (float)(t - (int)t);
+		float rx1 = rx0 - 1;
+
+		t = y + (float)N;
+		int by0 = ((int)t) & BM;
+		int by1 = (by0 + 1) & BM;
+		float ry0 = (float)(t - (int)t);
+		float ry1 = ry0 - 1;
+
+		t = z + (float)N;
+		int bz0 = ((int)t) & BM;
+		int bz1 = (bz0 + 1) & BM;
+		float rz0 = (float)(t - (int)t);
+		float rz1 = rz0 - 1;
+
+		int i = p[bx0];
+		int j = p[bx1];
+
+		int b00 = p[i + by0];
+		int b10 = p[j + by0];
+		int b01 = p[i + by1];
+		int b11 = p[j + by1];
+
+		t  = sCurve(rx0);
+		float sy = sCurve(ry0);
+		float sz = sCurve(rz0);
+
+		float[] q = g3[b00 + bz0];
+		float u = (rx0 * q[0] + ry0 * q[1] + rz0 * q[2]);
+		q = g3[b10 + bz0];
+		float v = (rx1 * q[0] + ry0 * q[1] + rz0 * q[2]);
+		float a = lerp(t, u, v);
+
+		q = g3[b01 + bz0];
+		u = (rx0 * q[0] + ry1 * q[1] + rz0 * q[2]);
+		q = g3[b11 + bz0];
+		v = (rx1 * q[0] + ry1 * q[1] + rz0 * q[2]);
+		float b = lerp(t, u, v);
+
+		float c = lerp(sy, a, b);
+
+		q = g3[b00 + bz1];
+		u = (rx0 * q[0] + ry0 * q[1] + rz1 * q[2]);
+		q = g3[b10 + bz1];
+		v = (rx1 * q[0] + ry0 * q[1] + rz1 * q[2]);
+		a = lerp(t, u, v);
+
+		q = g3[b01 + bz1];
+		u = (rx0 * q[0] + ry1 * q[1] + rz1 * q[2]);
+		q = g3[b11 + bz1];
+		v = (rx1 * q[0] + ry1 * q[1] + rz1 * q[2]);
+		b = lerp(t, u, v);
+
+		float d = lerp(sy, a, b);
+
+		return lerp(sz, c, d);
+	}
+
+	/**
+	 * Create a turbulent noise output based on the core noise function. This
+	 * uses the noise as a base function and is suitable for creating clouds,
+	 * marble and explosion effects. For example, a typical marble effect would
+	 * set the colour to be:
+	 * <pre>
+	 *	  sin(point + turbulence(point) * point.x);
+	 * </pre>
+	 */
+	public double imporvedTurbulence(double x,
+									 double y,
+									 double z,
+									 float loF,
+									 float hiF)
+	{
+		double p_x = x + 123.456f;
+		double p_y = y;
+		double p_z = z;
+		double t = 0;
+		double f;
+
+		for(f = loF; f < hiF; f *= 2)
+		{
+			t += Math.abs(improvedNoise(p_x, p_y, p_z)) / f;
+
+			p_x *= 2;
+			p_y *= 2;
+			p_z *= 2;
+		}
+
+		return t - 0.3;
+	}
+
+	/**
+	 * Create a turbulance function in 2D using the original perlin noise
+	 * function.
+	 *
+	 * @param x The X coordinate of the location to sample
+	 * @param y The Y coordinate of the location to sample
+	 * @param freq The frequency of the turbluance to create
+	 * @return The value at the given coordinates
+	 */
+	public float turbulence2(float x, float y, float freq)
+	{
+		float t = 0;
+
+		do
+		{
+			t += noise2(freq * x, freq * y) / freq;
+			freq *= 0.5f;
+		}
+		while (freq >= 1);
+
+		return t;
+	}
+
+	/**
+	 * Create a turbulance function in 3D using the original perlin noise
+	 * function.
+	 *
+	 * @param x The X coordinate of the location to sample
+	 * @param y The Y coordinate of the location to sample
+	 * @param z The Z coordinate of the location to sample
+	 * @param freq The frequency of the turbluance to create
+	 * @return The value at the given coordinates
+	 */
+	public float turbulence3(float x, float y, float z, float freq)
+	{
+		float t = 0;
+
+		do
+		{
+			t += noise3(freq * x, freq * y, freq * z) / freq;
+			freq *= 0.5f;
+		}
+		while (freq >= 1);
+
+		return t;
+	}
+
+	/**
+	 * Create a 1D tileable noise function for the given width.
+	 *
+	 * @param x The X coordinate to generate the noise for
+	 * @param w The width of the tiled block
+	 * @return The value of the noise at the given coordinate
+	 */
+	public float tileableNoise1(float x, float w)
+	{
+		return (noise1(x)	  * (w - x) +
+				noise1(x - w) *		 x) / w;
+	}
+
+	/**
+	 * Create a 2D tileable noise function for the given width and height.
+	 *
+	 * @param x The X coordinate to generate the noise for
+	 * @param y The Y coordinate to generate the noise for
+	 * @param w The width of the tiled block
+	 * @param h The height of the tiled block
+	 * @return The value of the noise at the given coordinate
+	 */
+	public float tileableNoise2(float x, float y, float w, float h)
+	{
+		return (noise2(x,	  y)	 * (w - x) * (h - y) +
+				noise2(x - w, y)	 *		x  * (h - y) +
+				noise2(x,	  y - h) * (w - x) *	  y  +
+				noise2(x - w, y - h) *		x  *	  y) / (w * h);
+	}
+
+	/**
+	 * Create a 3D tileable noise function for the given width, height and
+	 * depth.
+	 *
+	 * @param x The X coordinate to generate the noise for
+	 * @param y The Y coordinate to generate the noise for
+	 * @param z The Z coordinate to generate the noise for
+	 * @param w The width of the tiled block
+	 * @param h The height of the tiled block
+	 * @param d The depth of the tiled block
+	 * @return The value of the noise at the given coordinate
+	 */
+	public float tileableNoise3(float x,
+								float y,
+								float z,
+								float w,
+								float h,
+								float d)
+	{
+		return (noise3(x,	  y,	 z)		* (w - x) * (h - y) * (d - z) +
+				noise3(x - w, y,	 z)		*	   x  * (h - y) * (d - z) +
+				noise3(x,	  y - h, z)		* (w - x) *		 y	* (d - z) +
+				noise3(x - w, y - h, z)		*	   x  *		 y	* (d - z) +
+				noise3(x,	  y,	 z - d) * (w - x) * (h - y) *	   z  +
+				noise3(x - w, y,	 z - d) *	   x  * (h - y) *	   z  +
+				noise3(x,	  y - h, z - d) * (w - x) *		 y	*	   z  +
+				noise3(x - w, y - h, z - d) *	   x  *		 y	*	   z) /
+				(w * h * d);
+	}
+
+	/**
+	 * Create a turbulance function that can be tiled across a surface in 2D.
+	 *
+	 * @param x The X coordinate of the location to sample
+	 * @param y The Y coordinate of the location to sample
+	 * @param w The width to tile over
+	 * @param h The height to tile over
+	 * @param freq The frequency of the turbluance to create
+	 * @return The value at the given coordinates
+	 */
+	public float tileableTurbulence2(float x,
+									 float y,
+									 float w,
+									 float h,
+									 float freq)
+	{
+		float t = 0;
+
+		do
+		{
+			t += tileableNoise2(freq * x, freq * y, w * freq, h * freq) / freq;
+			freq *= 0.5f;
+		}
+		while (freq >= 1);
+
+		return t;
+	}
+
+	/**
+	 * Create a turbulance function that can be tiled across a surface in 3D.
+	 *
+	 * @param x The X coordinate of the location to sample
+	 * @param y The Y coordinate of the location to sample
+	 * @param z The Z coordinate of the location to sample
+	 * @param w The width to tile over
+	 * @param h The height to tile over
+	 * @param d The depth to tile over
+	 * @param freq The frequency of the turbluance to create
+	 * @return The value at the given coordinates
+	 */
+	public float tileableTurbulence3(float x,
+									 float y,
+									 float z,
+									 float w,
+									 float h,
+									 float d,
+									 float freq)
+	{
+		float t = 0;
+
+		do
+		{
+			t += tileableNoise3(freq * x,
+								freq * y,
+								freq * z,
+								w * freq,
+								h * freq,
+								d * freq) / freq;
+			freq *= 0.5f;
+		}
+		while (freq >= 1);
+
+		return t;
+	}
+
+
+	/**
+	 * Simple lerp function using doubles.
+	 */
+	private double lerp(double t, double a, double b)
+	{
+		return a + t * (b - a);
+	}
+
+	/**
+	 * Simple lerp function using floats.
+	 */
+	private float lerp(float t, float a, float b)
+	{
+		return a + t * (b - a);
+	}
+
+	/**
+	 * Fade curve calculation which is 6t^5 - 15t^4 + 10t^3. This is the new
+	 * algorithm, where the old one used to be 3t^2 - 2t^3.
+	 *
+	 * @param t The t parameter to calculate the fade for
+	 * @return the drop-off amount.
+	 */
+	private double fade(double t)
+	{
+		return t * t * t * (t * (t * 6 - 15) + 10);
+	}
+
+	/**
+	 * Calculate the gradient function based on the hash code.
+	 */
+	private double grad(int hash, double x, double y, double z)
+	{
+		// Convert low 4 bits of hash code into 12 gradient directions.
+		int h = hash & 15;
+		double u = (h < 8 || h == 12 || h == 13) ? x : y;
+		double v = (h < 4 || h == 12 || h == 13) ? y : z;
+
+		return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);
+	}
+
+	/**
+	 * Simple bias generator using exponents.
+	 */
+	private float bias(float a, float b)
+	{
+		return (float)Math.pow(a, Math.log(b) / LOG_HALF);
+	}
+
+
+	/*
+	 * Gain generator that caps to the range of [0, 1].
+	 */
+	private float gain(float a, float b)
+	{
+		if(a < 0.001f)
+			return 0;
+		else if (a > 0.999f)
+			return 1.0f;
+
+		double p = Math.log(1.0f - b) / LOG_HALF;
+
+		if(a < 0.5f)
+			return (float)(Math.pow(2 * a, p) / 2);
+		else
+			return 1 - (float)(Math.pow(2 * (1.0f - a), p) / 2);
+	}
+
+	/**
+	 * S-curve function for value distribution for Perlin-1 noise function.
+	 */
+	private float sCurve(float t)
+	{
+		return (t * t * (3 - 2 * t));
+	}
+
+	/**
+	 * 2D-vector normalisation function.
+	 */
+	private void normalize2(float[] v)
+	{
+		float s = (float)(1 / Math.sqrt(v[0] * v[0] + v[1] * v[1]));
+		v[0] *= s;
+		v[1] *= s;
+	}
+
+	/**
+	 * 3D-vector normalisation function.
+	 */
+	private void normalize3(float[] v)
+	{
+		float s = (float)(1 / Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]));
+		v[0] *= s;
+		v[1] *= s;
+		v[2] *= s;
+	}
+
+	/**
+	 * Initialise the lookup arrays used by Perlin 1 function.
+	 */
+	private void initPerlin1()
+	{
+		p = new int[B + B + 2];
+		g3 = new float[B + B + 2][3];
+		g2 = new float[B + B + 2][2];
+		g1 = new float[B + B + 2];
+		int i, j, k;
+
+		for(i = 0; i < B; i++)
+		{
+			p[i] = i;
+
+			g1[i] = (float)(((Math.random() * Integer.MAX_VALUE) % (B + B)) - B) / B;
+
+			for(j = 0; j < 2; j++)
+				g2[i][j] = (float)(((Math.random() * Integer.MAX_VALUE) % (B + B)) - B) / B;
+			normalize2(g2[i]);
+
+			for(j = 0; j < 3; j++)
+				g3[i][j] = (float)(((Math.random() * Integer.MAX_VALUE) % (B + B)) - B) / B;
+			normalize3(g3[i]);
+		}
+
+		while(--i > 0)
+		{
+			k = p[i];
+			j = (int)((Math.random() * Integer.MAX_VALUE) % B);
+			p[i] = p[j];
+			p[j] = k;
+		}
+
+		for(i = 0; i < B + 2; i++)
+		{
+			p[B + i] = p[i];
+			g1[B + i] = g1[i];
+			for(j = 0; j < 2; j++)
+				g2[B + i][j] = g2[i][j];
+			for(j = 0; j < 3; j++)
+				g3[B + i][j] = g3[i][j];
+		}
+	}
+}

--- a/src/main/java/openblocks/common/entity/EntityHangGlider.java
+++ b/src/main/java/openblocks/common/entity/EntityHangGlider.java
@@ -5,17 +5,43 @@ import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import java.util.GregorianCalendar;
 import java.util.Map;
+import java.util.Random;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
+import openblocks.Config;
 import openblocks.common.item.ItemHangGlider;
+import openblocks.common.BeepGenerator;
+import openblocks.common.PerlinNoiseGenerator;
 import openmods.Log;
 
 public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnData {
+	// Vario Config
+	public static boolean varioActive = false;
+	public static int varioVolume = 8;
+	public static final int VOL_MIN = 2;
+	public static final int VOL_MAX = 20;
+	public static final int FREQ_MIN = 300;
+	public static final int FREQ_AVG = 600;
+	public static final int FREQ_MAX = 2000;
+	public static final int BEEP_RATE_AVG = 4;
+	public static final int BEEP_RATE_MAX = 24;
+	public static final int TICKS_PER_VARIO_UPDATE = 4;
+	public static final int THERMAL_HEIGTH_MIN = 72;
+	public static final int THERMAL_HEIGTH_OPT = 110;
+	public static final int THERMAL_HEIGTH_MAX = 134;
+	public static final int THERMAL_STRONG_BONUS_HEIGTH = 100;
+	public static final double VSPEED_NORMAL = -0.052;
+	public static final double VSPEED_FAST = -0.176;
+	public static final double VSPEED_MIN = -0.25;
+	public static final double VSPEED_MAX = 0.5;
+
 	private static final int PROPERTY_DEPLOYED = 17;
 
 	private static Map<EntityPlayer, EntityHangGlider> gliderMap = new MapMaker().weakKeys().weakValues().makeMap();
@@ -27,7 +53,7 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 
 	public static boolean isGliderDeployed(Entity player) {
 		EntityHangGlider glider = gliderMap.get(player);
-		return glider == null || glider.isDeployed();
+		return glider != null && glider.isDeployed();
 	}
 
 	private static boolean isGliderValid(EntityPlayer player, EntityHangGlider glider) {
@@ -49,10 +75,35 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 		}
 	}
 
+	public static void toggleVario() {
+		if (!varioActive) {
+			varioActive = true;
+		} else {
+			varioActive = false;
+		}
+	}
+
+	public static void incVarioVol() {
+		varioVolume = Math.min((varioVolume + 2), VOL_MAX);
+		BeepGenerator.setVolume((byte) varioVolume);
+	}
+
+	public static void decVarioVol() {
+		varioVolume = Math.max((varioVolume - 2), VOL_MIN);
+		BeepGenerator.setVolume((byte) varioVolume);
+	}
+
 	private EntityPlayer player;
+	private PerlinNoiseGenerator noiseGen;
+	private BeepGenerator beeper;
+	private int ticksSinceLastVarioUpdate = 0;
+	private double avgVspeed = 0;
+	private double lastMotionY = 0;
 
 	public EntityHangGlider(World world) {
 		super(world);
+		this.noiseGen = new PerlinNoiseGenerator(world.getCurrentDate().get(GregorianCalendar.DAY_OF_YEAR));
+		BeepGenerator.setVolume((byte) varioVolume);
 	}
 
 	public EntityHangGlider(World world, EntityPlayer player) {
@@ -104,44 +155,94 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 			return;
 		}
 
-		boolean isDeployed = player.onGround || player.isInWater();
+		boolean isDeployed = !player.onGround && !player.isInWater();
 
 		if (!worldObj.isRemote) {
 			this.dataWatcher.updateObject(PROPERTY_DEPLOYED, (byte)(isDeployed? 1 : 0));
 			fixPositions(player, false);
 		}
 
-		if (!isDeployed && player.motionY < 0) {
+		if (isLocalPlayer() && Config.hanggliderEnableThermal && beeper == null)
+			beeper = new BeepGenerator();
+
+		if (isDeployed && player.motionY < lastMotionY) {
 			final double horizontalSpeed;
 			final double verticalSpeed;
+			final double noise;
+
+			if (Config.hanggliderEnableThermal)
+				noise = getNoise();
+			else
+				noise = 0;
+
+			final double vspeed = (noise >= 0 ? VSPEED_MAX : -VSPEED_MIN);
 
 			if (player.isSneaking()) {
 				horizontalSpeed = 0.1;
-				verticalSpeed = 0.7;
+				verticalSpeed = Math.max((VSPEED_FAST + noise * vspeed), VSPEED_MIN);
 			} else {
 				horizontalSpeed = 0.03;
-				verticalSpeed = 0.4;
+				verticalSpeed = Math.max((VSPEED_NORMAL + noise * vspeed), VSPEED_MIN);
 			}
 
-			player.motionY *= verticalSpeed;
-			motionY *= verticalSpeed;
+			player.motionY = verticalSpeed;
+			motionY = verticalSpeed;
+			lastMotionY = verticalSpeed;
+
+			if (isLocalPlayer()) {
+				if (varioActive) {
+					ticksSinceLastVarioUpdate++;
+					avgVspeed += verticalSpeed / (double) TICKS_PER_VARIO_UPDATE;
+					if (ticksSinceLastVarioUpdate > TICKS_PER_VARIO_UPDATE) {
+						vario(avgVspeed);
+						ticksSinceLastVarioUpdate = 0;
+						avgVspeed = 0;
+					}
+				} else {
+					stopVario();
+				}
+			}
+
 			double x = Math.cos(Math.toRadians(player.rotationYawHead + 90)) * horizontalSpeed;
 			double z = Math.sin(Math.toRadians(player.rotationYawHead + 90)) * horizontalSpeed;
 			player.motionX += x;
 			player.motionZ += z;
 			player.fallDistance = 0f; /* Don't like getting hurt :( */
+		} else if (isLocalPlayer() && varioActive) {
+			stopVario();
 		}
-
 	}
 
 	public EntityPlayer getPlayer() {
 		return player;
 	}
 
+	public double getNoise() {
+		double noise = (double) noiseGen.noise2((float) player.posX / 20f,(float) player.posZ / 20f);
+		final boolean strong = (noise > 0.8 ? true : false);
+		final int bonus = (strong ? THERMAL_STRONG_BONUS_HEIGTH : 0);
+		final int biomeRain = worldObj.getBiomeGenForCoords((int) player.posX, (int) player.posZ).getIntRainfall();
+
+		noise *= Math.min((Math.max((player.posY - (double) THERMAL_HEIGTH_MIN), 0d) / (double) (THERMAL_HEIGTH_OPT - THERMAL_HEIGTH_MIN)), 1d);
+		noise *= Math.min((Math.max(((double) (THERMAL_HEIGTH_MAX + bonus) - player.posY), 0d) / (double) (THERMAL_HEIGTH_MAX - THERMAL_HEIGTH_OPT + bonus / 4)), 1d);
+
+		int worldTime = (int) (worldObj.getWorldTime() % 24000);
+		noise *= Math.min(((double) worldTime / 1000d), 1);
+		noise *= Math.min(((double) Math.max((12000 - worldTime), 0) / 1000d), 1);
+
+		if (player.dimension != 0)
+			noise = 0;
+		else if (worldObj.isRaining() && !strong)
+			noise = (biomeRain > 0 ? -0.5 : 0);
+		return noise;
+	}
+
 	@Override
 	public void setDead() {
 		super.setDead();
 		gliderMap.remove(player);
+		if (isLocalPlayer())
+			stopVario();
 	}
 
 	private void fixPositions(EntityPlayer thePlayer, boolean localPlayer) {
@@ -169,6 +270,41 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 		this.motionX = this.posX - this.prevPosX;
 		this.motionY = this.posY - this.prevPosY;
 		this.motionZ = this.posZ - this.prevPosZ;
+	}
+
+	private boolean isLocalPlayer() {
+		return worldObj.isRemote && player == Minecraft.getMinecraft().thePlayer;
+	}
+
+	@SideOnly(Side.CLIENT)
+	private void vario(double vspeed) {
+		if (vspeed <= 0){
+			vspeed = Math.max(VSPEED_MIN, vspeed);
+			double freq = (vspeed - VSPEED_MIN) / Math.abs(VSPEED_MIN) * (double) (FREQ_AVG - FREQ_MIN) + (double) FREQ_MIN;
+			beeper.setToneFrequency(freq);
+			beeper.setBeepFrequency(0d);
+		} else {
+			vspeed = Math.min(VSPEED_MAX, vspeed);
+			double freq = vspeed / Math.abs(VSPEED_MAX) * (double) (FREQ_MAX - FREQ_AVG) + (double) FREQ_AVG;
+			double beepfreq = vspeed / Math.abs(VSPEED_MAX) * (double) (BEEP_RATE_MAX - BEEP_RATE_AVG) + (double) BEEP_RATE_AVG;
+			beeper.setToneFrequency(freq);
+			beeper.setBeepFrequency(beepfreq);
+		}
+		if (beeper.isRunning()) {
+			beeper.keepAlive();
+		} else {
+			beeper.start();
+		}
+	}
+
+	@SideOnly(Side.CLIENT)
+	private void stopVario() {
+		if (beeper != null) {
+			beeper.stop();
+			beeper = null;
+		}
+		ticksSinceLastVarioUpdate = 0;
+		avgVspeed = 0;
 	}
 
 	@Override

--- a/src/main/java/openblocks/common/tileentity/TileEntityTank.java
+++ b/src/main/java/openblocks/common/tileentity/TileEntityTank.java
@@ -329,6 +329,8 @@ public class TileEntityTank extends SyncedTileEntity implements IActivateAwareTi
 			sum += n.tank.getFluidAmount();
 
 		final int suggestedAmount = sum / (count + 1);
+		if (Math.abs(suggestedAmount - contents.amount) < 5) return; // Don't balance small amounts to reduce server load
+
 		FluidStack suggestedStack = contents.copy();
 		suggestedStack.amount = suggestedAmount;
 

--- a/src/main/resources/assets/openblocks/lang/de_DE.lang
+++ b/src/main/resources/assets/openblocks/lang/de_DE.lang
@@ -6,6 +6,9 @@ achievement.openblocks.stackOverflow.desc=Es ist voller Sterne!
 
 openblocks.keybind.category=OpenBlocks
 openblocks.keybind.drop_brick=Sei albern
+openblocks.keybind.vario_switch=Vario Ein/Aus
+openblocks.keybind.vario_vol_up=Vario lauter
+openblocks.keybind.vario_vol_down=Vario leiser
 
 enchantment.openblocks.explosive=Instabil
 enchantment.openblocks.laststand=Letzte Rettung
@@ -92,7 +95,7 @@ openblocks.misc.page=Seite %d von %d
 openblocks.misc.oh_no_ceiling=Du kannst hier nicht schlafen. Die Decke beunruhigt dich zu sehr...
 openblocks.misc.oh_no_ground=Auf DEM Ding willst du schlafen?!
 openblocks.misc.sleeping_bag_broken=Item inaktiv wegen fehlerhafter Initialisierung
-#openblocks.misc.inverted=Inverted ## NEEDS TRANSLATION ##
+openblocks.misc.inverted=Invertiert
 
 openblocks.misc.grave_msg=%s (Tag: %.1f)
 

--- a/src/main/resources/assets/openblocks/lang/en_US.lang
+++ b/src/main/resources/assets/openblocks/lang/en_US.lang
@@ -6,6 +6,9 @@ achievement.openblocks.stackOverflow.desc=It's full of stars!
 
 openblocks.keybind.category=OpenBlocks
 openblocks.keybind.drop_brick=Be silly
+openblocks.keybind.vario_switch=Vario on/off
+openblocks.keybind.vario_vol_up=Vario volume up
+openblocks.keybind.vario_vol_down=Vario volume down
 
 enchantment.openblocks.explosive=Unstable
 enchantment.openblocks.laststand=Last Stand


### PR DESCRIPTION
Adds a whole new thermal system to hanggliders:
- based on real-world gliding experience
- adds thermal lifts to the world (based on 2D-random-noise)
- there are updrafts as well as downdrafts so plan your flight wisely and you can travel nice distances
- depending on the weather, time of day, dimension, biome and most important the player's heigth
- heigth limit is cloud-level (or is it?)
- multiplayer enabled (thermals are synchronized so you can fly with your buddys)
- optimized for performance (works without complex data types or lookups)
- doesn't touch the world at all (so no risk for safegames)
- it's optional (you can turn it off in the config)

Also there's an acoustic variometer that can be activated (deactivated by default; default key-binding V). It indicates the current average up- or downdraft. Vario sound is not played to other players. The volume is controllable.


Additionally this fixes lags caused by massive use of the OpenBlocks-Tanks. Neighbouring tanks constantly tried to balance their liquid amounts - causing a big number of block updates every tick. This is fixed by ignoring small differences ( < 5 millibuckets) so balancing quickly settles and causes no further block-updates after that.