### PR TITLE
Fix server lags caused by constantly ticking tanks.

### DIFF
--- a/src/main/java/openblocks/common/tileentity/TileEntityTank.java
+++ b/src/main/java/openblocks/common/tileentity/TileEntityTank.java
@@ -329,6 +329,8 @@ public class TileEntityTank extends SyncedTileEntity implements IActivateAwareTi
 			sum += n.tank.getFluidAmount();
 
 		final int suggestedAmount = sum / (count + 1);
+		if (Math.abs(suggestedAmount - contents.amount) < 5) return; // Don't balance small amounts to reduce server load
+
 		FluidStack suggestedStack = contents.copy();
 		suggestedStack.amount = suggestedAmount;
 


### PR DESCRIPTION
This fixes lags caused by massive use of the OpenBlocks-Tanks. Neighbouring tanks constantly tried to balance their liquid amounts - causing a big number of block updates every tick. This is fixed by ignoring small differences ( < 5 millibuckets) so balancing quickly settles and causes no further block-updates after that.