### PR TITLE
Optional thermal lifts for the hangglider (incl. opt. acoustic vario)

### DIFF
--- a/src/main/java/openblocks/Config.java
+++ b/src/main/java/openblocks/Config.java
@@ -380,6 +380,10 @@ public class Config {
 	@ConfigProperty(category = "devnull", name = "sneakClickToGui", comment = "If true, /dev/null will require sneaking in addition to clicking air to open gui")
 	public static boolean devNullSneakGui = true;
 
+	@OnLineModifiable
+	@ConfigProperty(category = "hangglider", name = "enableThermal", comment = "Enable a whole new level of hanggliding experience through thermal lift. See keybindings for acoustic vario controls")
+	public static boolean hanggliderEnableThermal = true;
+
 	public static void register() {
 		@SuppressWarnings("unchecked")
 		final List<IRecipe> recipeList = CraftingManager.getInstance().getRecipeList();

--- a/src/main/java/openblocks/client/GliderPlayerRenderHandler.java
+++ b/src/main/java/openblocks/client/GliderPlayerRenderHandler.java
@@ -11,7 +11,7 @@ public class GliderPlayerRenderHandler {
 	@SubscribeEvent
 	public void onPlayerBodyRender(PlayerBodyRenderEvent evt) {
 		final AbstractClientPlayer player = evt.player;
-		if (!EntityHangGlider.isGliderDeployed(player)) {
+		if (EntityHangGlider.isGliderDeployed(player)) {
 			player.limbSwing = 0f;
 			player.prevLimbSwingAmount = 0f;
 			player.limbSwingAmount = 0f;

--- a/src/main/java/openblocks/client/bindings/KeyInputHandler.java
+++ b/src/main/java/openblocks/client/bindings/KeyInputHandler.java
@@ -7,19 +7,34 @@ import cpw.mods.fml.common.gameevent.InputEvent;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.settings.KeyBinding;
 import openblocks.Config;
+import openblocks.common.entity.EntityHangGlider;
 import openblocks.events.PlayerActionEvent;
 import org.lwjgl.input.Keyboard;
 
 public class KeyInputHandler {
 
 	private KeyBinding brickBinding;
+	private KeyBinding varioSwitchBinding;
+	private KeyBinding varioVolUpBinding;
+	private KeyBinding varioVolDownBinding;
 
 	private boolean brickKeyPressed;
+	private boolean varioSwitchKeyPressed;
+	private boolean varioVolUpKeyPressed;
+	private boolean varioVolDownKeyPressed;
 
 	public void setup() {
 		if (!Config.soSerious) {
 			brickBinding = new KeyBinding("openblocks.keybind.drop_brick", Keyboard.KEY_B, "openblocks.keybind.category");
 			ClientRegistry.registerKeyBinding(brickBinding);
+		}
+		if (Config.hanggliderEnableThermal) {
+			varioSwitchBinding = new KeyBinding("openblocks.keybind.vario_switch", Keyboard.KEY_V, "openblocks.keybind.category");
+			varioVolUpBinding = new KeyBinding("openblocks.keybind.vario_vol_up", Keyboard.KEY_NONE, "openblocks.keybind.category");
+			varioVolDownBinding = new KeyBinding("openblocks.keybind.vario_vol_down", Keyboard.KEY_NONE, "openblocks.keybind.category");
+			ClientRegistry.registerKeyBinding(varioSwitchBinding);
+			ClientRegistry.registerKeyBinding(varioVolUpBinding);
+			ClientRegistry.registerKeyBinding(varioVolDownBinding);
 		}
 		FMLCommonHandler.instance().bus().register(this);
 	}
@@ -36,6 +51,24 @@ public class KeyInputHandler {
 				brickKeyPressed = true;
 			}
 		} else brickKeyPressed = false;
+		if (varioSwitchBinding != null && varioSwitchBinding.isPressed()) {
+			if (!varioSwitchKeyPressed) {
+				EntityHangGlider.toggleVario();
+				varioSwitchKeyPressed = true;
+			}
+		} else varioSwitchKeyPressed = false;
+		if (varioVolUpBinding != null && varioVolUpBinding.isPressed()) {
+			if (!varioVolUpKeyPressed) {
+				EntityHangGlider.incVarioVol();
+				varioVolUpKeyPressed = true;
+			}
+		} else varioVolUpKeyPressed = false;
+		if (varioVolDownBinding != null && varioVolDownBinding.isPressed()) {
+			if (!varioVolDownKeyPressed) {
+				EntityHangGlider.decVarioVol();
+				varioVolDownKeyPressed = true;
+			}
+		} else varioVolDownKeyPressed = false;
 	}
 
 }

--- a/src/main/java/openblocks/client/renderer/entity/EntityHangGliderRenderer.java
+++ b/src/main/java/openblocks/client/renderer/entity/EntityHangGliderRenderer.java
@@ -52,7 +52,7 @@ public class EntityHangGliderRenderer extends Render {
 		final boolean isFpp = minecraft.gameSettings.thirdPersonView == 0;
 		final boolean isDeployed = glider.isDeployed();
 
-		if (isLocalPlayer && isFpp && isDeployed) return;
+		if (isLocalPlayer && isFpp && !isDeployed) return;
 
 		final float rotation = interpolateRotation(glider.prevRotationYaw, glider.rotationYaw, f1);
 
@@ -62,7 +62,7 @@ public class EntityHangGliderRenderer extends Render {
 		GL11.glRotatef(180.0F - rotation, 0.0F, 1.0F, 0.0F);
 
 		if (isLocalPlayer) {
-			if (isDeployed) {
+			if (!isDeployed) {
 				// move up and closer to back
 				GL11.glTranslated(0, -0.2, +0.3);
 			} else {
@@ -75,7 +75,7 @@ public class EntityHangGliderRenderer extends Render {
 				}
 			}
 		} else {
-			if (isDeployed) {
+			if (!isDeployed) {
 				// move up little bit (other player center is lower)
 				GL11.glTranslated(0, +0.2, +0.3);
 			} else {
@@ -84,7 +84,7 @@ public class EntityHangGliderRenderer extends Render {
 			}
 		}
 
-		if (isDeployed) {
+		if (!isDeployed) {
 			GL11.glRotatef(ONGROUND_ROTATION, 1, 0, 0);
 			GL11.glScalef(0.4f, 1f, 0.4f);
 		}

--- a/src/main/java/openblocks/common/BeepGenerator.java
+++ b/src/main/java/openblocks/common/BeepGenerator.java
@@ -1,0 +1,221 @@
+package openblocks.common;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.audio.SoundCategory;
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.SourceDataLine;
+
+public class BeepGenerator {
+
+	private static final int SAMPLE_RATE = 128 * 1024;
+	private static final int MIN_BUFFER_AVAILABLE = (int) (SAMPLE_RATE * 64 / 1000);
+	private static final int TIMEOUT_SECONDS = 1;
+
+	private static byte volume = 8;
+
+	public static byte getVolume() {
+		return volume;
+	}
+
+	public static void setVolume(byte volume) {
+		BeepGenerator.volume = volume;
+	}
+
+	private byte[] buffer;
+	private int bufferSize;
+	private boolean currentlyBeeping;
+	private boolean running;
+
+	private double toneFrequency;
+	private double lastToneFrequency;
+	private double beepFrequency;
+	private int samplesSinceLastBeepChange;
+	private int timeout;
+
+	private SourceDataLine line;
+
+	private Thread writer;
+
+	public BeepGenerator() {
+		running = false;
+	}
+
+	public void start() {
+		running = true;
+		timeout = TIMEOUT_SECONDS * 10;
+
+		AudioFormat af = new AudioFormat(SAMPLE_RATE, 8, 1, true, true);
+		try {
+			this.line = AudioSystem.getSourceDataLine(af);
+			this.line.open(af, SAMPLE_RATE);
+		} catch (LineUnavailableException e) {
+			e.printStackTrace();
+		}
+		bufferSize = this.line.getBufferSize();
+
+		startWriter();
+		startTimeout();
+	}
+
+	public void stop() {
+		timeout = 0;
+		setToneFrequency(0d);
+		setBeepFrequency(0d);
+	}
+
+	public void keepAlive() {
+		timeout = TIMEOUT_SECONDS * 10;
+	}
+
+	public boolean isRunning() {
+		return running;
+	}
+
+	private void startWriter() {
+		new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+				long t;
+
+				writeSample();
+				writeSample();
+
+				BeepGenerator.this.line.start();
+
+				int kill = 5;
+
+				while (BeepGenerator.this.running) {
+
+					writeSample();
+
+					// Calculate sleep in ms from buffer-surplus
+					int bufferAvailable = bufferSize - BeepGenerator.this.line.available();
+					int ms = (int) ((double) (bufferAvailable - MIN_BUFFER_AVAILABLE) / ((double) (SAMPLE_RATE) / 1000d));
+
+					if (ms <= 8)
+						continue;
+
+					// Fixes a weird bug (BeepGenerator.this.line.available() returning 0)
+					if (bufferAvailable == bufferSize) {
+						BeepGenerator.this.line.stop();
+						while (bufferAvailable == bufferSize || bufferAvailable <= MIN_BUFFER_AVAILABLE) {
+							writeSample();
+							bufferAvailable = bufferSize - BeepGenerator.this.line.available();
+						}
+						BeepGenerator.this.line.start();
+						continue;
+					}
+
+					if (ms < 100)
+						kill = 5;
+
+					if (kill == 0) {
+						stop();
+					} else {
+						kill--;
+					}
+
+					try {
+						Thread.sleep(ms);
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
+
+				}
+				BeepGenerator.this.line.close();
+			}
+		}).start();
+	}
+
+	private void startTimeout() {
+		new Thread(new Runnable() {
+
+			@Override
+			public void run() {
+				while (BeepGenerator.this.running) {
+					BeepGenerator.this.timeout--;
+					try {
+						Thread.sleep(100);
+					} catch (InterruptedException e) {
+						e.printStackTrace();
+					}
+					if (BeepGenerator.this.timeout <= 0)
+						BeepGenerator.this.running = false;
+				}
+			}
+		}).start();
+	}
+
+	private void writeSample() {
+		if (this.lastToneFrequency == 0d || this.getToneFrequency() == 0d)
+			this.lastToneFrequency = this.getToneFrequency();
+		else if (this.lastToneFrequency < this.getToneFrequency())
+			this.lastToneFrequency += Math.min(5d, this.getToneFrequency() - this.lastToneFrequency);
+		else if (this.lastToneFrequency > this.getToneFrequency())
+			this.lastToneFrequency -= Math.min(5d, this.lastToneFrequency - this.getToneFrequency());
+
+		BeepGenerator.this.generateSample(this.lastToneFrequency);
+		line.write(BeepGenerator.this.buffer, 0, this.buffer.length);
+	}
+
+	private void generateSample(double frequency) {
+
+		final int samples = (int) (SAMPLE_RATE * 16 / 1000);
+		final float soundLevel = Minecraft.getMinecraft().gameSettings.getSoundLevel(SoundCategory.MASTER);
+
+		if (frequency == 0.0) {
+			this.buffer = new byte[samples];
+			return;
+		}
+
+		double sinLength = (SAMPLE_RATE/frequency);
+
+		int sinSmooth = (int) (sinLength - (int)(samples % sinLength));
+
+		this.buffer = new byte[samples + sinSmooth];
+
+		final int samplesPerBeep;
+		float vol;
+		if (getBeepFrequency() > 0) {
+			samplesPerBeep = (int) ((double) SAMPLE_RATE / getBeepFrequency());
+			vol = (byte) (this.currentlyBeeping ? this.volume : 0);
+		} else {
+			samplesPerBeep = 0;
+			vol = this.volume;
+			this.currentlyBeeping = true;
+		}
+
+		vol = (soundLevel != 0 ? Math.max((vol * soundLevel), 2) : 0);
+
+		for (int i = 0; i < this.buffer.length; i++) {
+			this.buffer[i] = (byte) (Math.sin((2.0 * Math.PI * i) / sinLength) * vol);
+			samplesSinceLastBeepChange++;
+			if (samplesPerBeep > 0 && samplesSinceLastBeepChange >= samplesPerBeep) {
+				this.currentlyBeeping = !this.currentlyBeeping;
+				if (soundLevel == 0) this.currentlyBeeping = false;
+				vol = (this.currentlyBeeping ? Math.max(((float) this.volume * soundLevel), 2) : 0);
+				samplesSinceLastBeepChange = 0;
+			}
+		}
+	}
+
+	public double getToneFrequency() {
+		return toneFrequency;
+	}
+
+	public void setToneFrequency(double frequency) {
+		this.toneFrequency = frequency;
+	}
+
+	public double getBeepFrequency() {
+		return beepFrequency;
+	}
+
+	public void setBeepFrequency(double beepFrequency) {
+		this.beepFrequency = beepFrequency;
+	}
+
+}

--- a/src/main/java/openblocks/common/entity/EntityHangGlider.java
+++ b/src/main/java/openblocks/common/entity/EntityHangGlider.java
@@ -5,17 +5,43 @@ import cpw.mods.fml.common.registry.IEntityAdditionalSpawnData;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import io.netty.buffer.ByteBuf;
+import java.util.GregorianCalendar;
 import java.util.Map;
+import java.util.Random;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
+import net.minecraft.world.gen.NoiseGeneratorPerlin;
+import openblocks.Config;
 import openblocks.common.item.ItemHangGlider;
+import openblocks.common.BeepGenerator;
 import openmods.Log;
+import openmods.OpenMods;
 
 public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnData {
+	// Vario Config
+	public static boolean varioActive = false;
+	public static int varioVolume = 8;
+	public static final int VOL_MIN = 2;
+	public static final int VOL_MAX = 20;
+	public static final int FREQ_MIN = 300;
+	public static final int FREQ_AVG = 600;
+	public static final int FREQ_MAX = 2000;
+	public static final int BEEP_RATE_AVG = 4;
+	public static final int BEEP_RATE_MAX = 24;
+	public static final int TICKS_PER_VARIO_UPDATE = 4;
+	public static final int THERMAL_HEIGTH_MIN = 70;
+	public static final int THERMAL_HEIGTH_OPT = 110;
+	public static final int THERMAL_HEIGTH_MAX = 136;
+	public static final int THERMAL_STRONG_BONUS_HEIGTH = 100;
+	public static final double VSPEED_NORMAL = -0.052;
+	public static final double VSPEED_FAST = -0.176;
+	public static final double VSPEED_MIN = -0.32;
+	public static final double VSPEED_MAX = 0.4;
+
 	private static final int PROPERTY_DEPLOYED = 17;
 
 	private static Map<EntityPlayer, EntityHangGlider> gliderMap = new MapMaker().weakKeys().weakValues().makeMap();
@@ -27,7 +53,7 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 
 	public static boolean isGliderDeployed(Entity player) {
 		EntityHangGlider glider = gliderMap.get(player);
-		return glider == null || glider.isDeployed();
+		return glider != null && glider.isDeployed();
 	}
 
 	private static boolean isGliderValid(EntityPlayer player, EntityHangGlider glider) {
@@ -49,10 +75,35 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 		}
 	}
 
+	public static void toggleVario() {
+		if (!varioActive) {
+			varioActive = true;
+		} else {
+			varioActive = false;
+		}
+	}
+
+	public static void incVarioVol() {
+		varioVolume = Math.min((varioVolume + 2), VOL_MAX);
+		BeepGenerator.setVolume((byte) varioVolume);
+	}
+
+	public static void decVarioVol() {
+		varioVolume = Math.max((varioVolume - 2), VOL_MIN);
+		BeepGenerator.setVolume((byte) varioVolume);
+	}
+
 	private EntityPlayer player;
+	private NoiseGeneratorPerlin noiseGen;
+	private BeepGenerator beeper;
+	private int ticksSinceLastVarioUpdate = 0;
+	private double avgVspeed = 0;
+	private double lastMotionY = 0;
 
 	public EntityHangGlider(World world) {
 		super(world);
+		this.noiseGen = new NoiseGeneratorPerlin(new Random(world.getCurrentDate().get(GregorianCalendar.DAY_OF_YEAR)), 2);
+		BeepGenerator.setVolume((byte) varioVolume);
 	}
 
 	public EntityHangGlider(World world, EntityPlayer player) {
@@ -104,44 +155,94 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 			return;
 		}
 
-		boolean isDeployed = player.onGround || player.isInWater();
+		boolean isDeployed = !player.onGround && !player.isInWater();
 
 		if (!worldObj.isRemote) {
 			this.dataWatcher.updateObject(PROPERTY_DEPLOYED, (byte)(isDeployed? 1 : 0));
 			fixPositions(player, false);
 		}
 
-		if (!isDeployed && player.motionY < 0) {
+		if (isLocalPlayer() && Config.hanggliderEnableThermal && beeper == null)
+			beeper = new BeepGenerator();
+
+		if (isDeployed && player.motionY < lastMotionY) {
 			final double horizontalSpeed;
 			final double verticalSpeed;
+			final double noise;
+
+			if (Config.hanggliderEnableThermal)
+				noise = getNoise();
+			else
+				noise = 0;
+
+			final double vspeed = (noise >= 0 ? VSPEED_MAX : -VSPEED_MIN);
 
 			if (player.isSneaking()) {
 				horizontalSpeed = 0.1;
-				verticalSpeed = 0.7;
+				verticalSpeed = Math.max((VSPEED_FAST + noise * vspeed), VSPEED_MIN);
 			} else {
 				horizontalSpeed = 0.03;
-				verticalSpeed = 0.4;
+				verticalSpeed = Math.max((VSPEED_NORMAL + noise * vspeed), VSPEED_MIN);
 			}
 
-			player.motionY *= verticalSpeed;
-			motionY *= verticalSpeed;
+			player.motionY = verticalSpeed;
+			motionY = verticalSpeed;
+			lastMotionY = verticalSpeed;
+
+			if (isLocalPlayer()) {
+				if (varioActive) {
+					ticksSinceLastVarioUpdate++;
+					avgVspeed += verticalSpeed / (double) TICKS_PER_VARIO_UPDATE;
+					if (ticksSinceLastVarioUpdate > TICKS_PER_VARIO_UPDATE) {
+						vario(avgVspeed);
+						ticksSinceLastVarioUpdate = 0;
+						avgVspeed = 0;
+					}
+				} else {
+					stopVario();
+				}
+			}
+
 			double x = Math.cos(Math.toRadians(player.rotationYawHead + 90)) * horizontalSpeed;
 			double z = Math.sin(Math.toRadians(player.rotationYawHead + 90)) * horizontalSpeed;
 			player.motionX += x;
 			player.motionZ += z;
 			player.fallDistance = 0f; /* Don't like getting hurt :( */
+		} else if (isLocalPlayer() && varioActive) {
+			stopVario();
 		}
-
 	}
 
 	public EntityPlayer getPlayer() {
 		return player;
 	}
 
+	public double getNoise() {
+		double noise = (double) noiseGen.func_151601_a((float) player.posX / 20f,(float) player.posZ / 20f) / 4d;
+		final boolean strong = (noise > 0.7 ? true : false);
+		final int bonus = (strong ? THERMAL_STRONG_BONUS_HEIGTH : 0);
+		final int biomeRain = worldObj.getBiomeGenForCoords((int) player.posX, (int) player.posZ).getIntRainfall();
+
+		noise *= Math.min((Math.max((player.posY - (double) THERMAL_HEIGTH_MIN), 0d) / (double) (THERMAL_HEIGTH_OPT - THERMAL_HEIGTH_MIN)), 1d);
+		noise *= Math.min((Math.max(((double) (THERMAL_HEIGTH_MAX + bonus) - player.posY), 0d) / (double) (THERMAL_HEIGTH_MAX - THERMAL_HEIGTH_OPT + bonus / 4)), 1d);
+
+		int worldTime = (int) (worldObj.getWorldTime() % 24000);
+		noise *= Math.min(((double) worldTime / 1000d), 1);
+		noise *= Math.min(((double) Math.max((12000 - worldTime), 0) / 1000d), 1);
+
+		if (player.dimension != 0)
+			noise = 0;
+		else if (worldObj.isRaining() && !strong)
+			noise = (biomeRain > 0 ? -0.5 : 0);
+		return noise;
+	}
+
 	@Override
 	public void setDead() {
 		super.setDead();
 		gliderMap.remove(player);
+		if (isLocalPlayer())
+			stopVario();
 	}
 
 	private void fixPositions(EntityPlayer thePlayer, boolean localPlayer) {
@@ -169,6 +270,41 @@ public class EntityHangGlider extends Entity implements IEntityAdditionalSpawnDa
 		this.motionX = this.posX - this.prevPosX;
 		this.motionY = this.posY - this.prevPosY;
 		this.motionZ = this.posZ - this.prevPosZ;
+	}
+
+	private boolean isLocalPlayer() {
+		return worldObj.isRemote && OpenMods.proxy.isClientPlayer(player);
+	}
+
+	@SideOnly(Side.CLIENT)
+	private void vario(double vspeed) {
+		if (vspeed <= 0){
+			vspeed = Math.max(VSPEED_MIN, vspeed);
+			double freq = (vspeed - VSPEED_MIN) / Math.abs(VSPEED_MIN) * (double) (FREQ_AVG - FREQ_MIN) + (double) FREQ_MIN;
+			beeper.setToneFrequency(freq);
+			beeper.setBeepFrequency(0d);
+		} else {
+			vspeed = Math.min(VSPEED_MAX, vspeed);
+			double freq = vspeed / Math.abs(VSPEED_MAX) * (double) (FREQ_MAX - FREQ_AVG) + (double) FREQ_AVG;
+			double beepfreq = vspeed / Math.abs(VSPEED_MAX) * (double) (BEEP_RATE_MAX - BEEP_RATE_AVG) + (double) BEEP_RATE_AVG;
+			beeper.setToneFrequency(freq);
+			beeper.setBeepFrequency(beepfreq);
+		}
+		if (beeper.isRunning()) {
+			beeper.keepAlive();
+		} else {
+			beeper.start();
+		}
+	}
+
+	@SideOnly(Side.CLIENT)
+	private void stopVario() {
+		if (beeper != null) {
+			beeper.stop();
+			beeper = null;
+		}
+		ticksSinceLastVarioUpdate = 0;
+		avgVspeed = 0;
 	}
 
 	@Override

--- a/src/main/resources/assets/openblocks/lang/de_DE.lang
+++ b/src/main/resources/assets/openblocks/lang/de_DE.lang
@@ -6,6 +6,9 @@ achievement.openblocks.stackOverflow.desc=Es ist voller Sterne!
 
 openblocks.keybind.category=OpenBlocks
 openblocks.keybind.drop_brick=Sei albern
+openblocks.keybind.vario_switch=Vario Ein/Aus
+openblocks.keybind.vario_vol_up=Vario lauter
+openblocks.keybind.vario_vol_down=Vario leiser
 
 enchantment.openblocks.explosive=Instabil
 enchantment.openblocks.laststand=Letzte Rettung
@@ -92,7 +95,7 @@ openblocks.misc.page=Seite %d von %d
 openblocks.misc.oh_no_ceiling=Du kannst hier nicht schlafen. Die Decke beunruhigt dich zu sehr...
 openblocks.misc.oh_no_ground=Auf DEM Ding willst du schlafen?!
 openblocks.misc.sleeping_bag_broken=Item inaktiv wegen fehlerhafter Initialisierung
-#openblocks.misc.inverted=Inverted ## NEEDS TRANSLATION ##
+openblocks.misc.inverted=Invertiert
 
 openblocks.misc.grave_msg=%s (Tag: %.1f)
 

--- a/src/main/resources/assets/openblocks/lang/en_US.lang
+++ b/src/main/resources/assets/openblocks/lang/en_US.lang
@@ -6,6 +6,9 @@ achievement.openblocks.stackOverflow.desc=It's full of stars!
 
 openblocks.keybind.category=OpenBlocks
 openblocks.keybind.drop_brick=Be silly
+openblocks.keybind.vario_switch=Vario on/off
+openblocks.keybind.vario_vol_up=Vario volume up
+openblocks.keybind.vario_vol_down=Vario volume down
 
 enchantment.openblocks.explosive=Unstable
 enchantment.openblocks.laststand=Last Stand


### PR DESCRIPTION
Adds a whole new thermal system to hanggliders:
- based on real-world gliding experience
- adds thermal lifts to the world (based on 2D-random-noise)
- there are updrafts as well as downdrafts so plan your flight wisely and you can travel nice distances
- depending on the weather, time of day, dimension, biome and most important the player's heigth
- heigth limit is cloud-level (or is it?)
- multiplayer enabled (thermals are synchronized so you can fly with your buddys)
- optimized for performance (works without complex data types or lookups)
- doesn't touch the world at all (so no risk for safegames)
- it's optional (you can turn it off in the config)

Also there's an acoustic variometer that can be activated (deactivated by default; default key-binding V). It indicates the current average up- or downdraft. Vario sound is not played to other players. The volume is controllable.

I adressed most of the comments, but left the rng-seed and the enableThermal setting untouched. Change that as you like.