### PR TITLE
ItemCannon fixes

### DIFF
--- a/src/main/java/openblocks/common/entity/EntityItemProjectile.java
+++ b/src/main/java/openblocks/common/entity/EntityItemProjectile.java
@@ -37,66 +37,21 @@ public class EntityItemProjectile extends EntityItem {
 		fixer.registerWalker(FixTypes.ENTITY, new ItemStackData(EntityItemProjectile.class, "Item"));
 	}
 
+	private boolean firstUpdate = true;
+
 	@Override
 	public void onUpdate() {
-		final double x = posX;
-		final double y = posY;
-		final double z = posZ;
-
-		final double vx = motionX;
-		final double vy = motionY;
-		final double vz = motionZ;
+		// Remove the air drag that EntityItem.onUpdate adds to our velocity
+		if (!firstUpdate && !this.onGround) {
+			float f = 0.98F;
+			this.motionX = this.motionX / f;
+			this.motionY = this.motionY / f;
+			this.motionZ = this.motionZ / f;
+		}
+		firstUpdate = false;
 
 		// let vanilla run
 		super.onUpdate();
-		if (!isDead) return;
-		// and then overwrite position calculations
-
-		this.posX = x;
-		this.posY = y;
-		this.posZ = z;
-
-		this.motionX = vx;
-		this.motionY = vy;
-		this.motionZ = vz;
-
-		this.prevPosX = this.posX;
-		this.prevPosY = this.posY;
-		this.prevPosZ = this.posZ;
-		this.motionY -= 0.03999999910593033D;
-
-		move(MoverType.SELF, this.motionX, this.motionY, this.motionZ);
-
-		boolean hasMoved = (int)this.prevPosX != (int)this.posX || (int)this.prevPosY != (int)this.posY || (int)this.prevPosZ != (int)this.posZ;
-
-		if (hasMoved || this.ticksExisted % 25 == 0) {
-			if (this.world.getBlockState(new BlockPos(this)).getMaterial() == Material.LAVA) {
-				this.motionY = 0.20000000298023224D;
-				this.motionX = (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F;
-				this.motionZ = (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F;
-				playSound(SoundEvents.ENTITY_GENERIC_BURN, 0.4F, 2.0F + this.rand.nextFloat() * 0.4F);
-			}
-		}
-
-		// Zero Air Friction
-		float f = 1F;
-
-		// Keep ground friction
-		if (this.onGround) {
-			BlockPos underPos = new BlockPos(MathHelper.floor(this.posX), MathHelper.floor(getEntityBoundingBox().minY) - 1, MathHelper.floor(this.posZ));
-			IBlockState underState = this.world.getBlockState(underPos);
-			f = underState.getBlock().getSlipperiness(underState, this.world, underPos, this) * 0.98F;
-		}
-
-		this.motionX *= f;
-		// Y would there be Y resistance :D
-		// ^ not my pun, I'm just porting :P, ~B
-		// motionY *= 0.98;
-		this.motionZ *= f;
-
-		if (this.onGround) this.motionY *= -0.5D;
-
-		handleWaterMovement();
 	}
 
 }

--- a/src/main/java/openblocks/common/entity/EntityItemProjectile.java
+++ b/src/main/java/openblocks/common/entity/EntityItemProjectile.java
@@ -37,21 +37,18 @@ public class EntityItemProjectile extends EntityItem {
 		fixer.registerWalker(FixTypes.ENTITY, new ItemStackData(EntityItemProjectile.class, "Item"));
 	}
 
-	private boolean firstUpdate = true;
-
 	@Override
 	public void onUpdate() {
+		// let vanilla run
+		super.onUpdate();
+
 		// Remove the air drag that EntityItem.onUpdate adds to our velocity
-		if (!firstUpdate && !this.onGround) {
-			float f = 0.98F;
+		if (!this.onGround) {
+			double f = 0.98F;
 			this.motionX = this.motionX / f;
 			this.motionY = this.motionY / f;
 			this.motionZ = this.motionZ / f;
 		}
-		firstUpdate = false;
-
-		// let vanilla run
-		super.onUpdate();
 	}
 
 }

--- a/src/main/java/openblocks/common/tileentity/TileEntityCannon.java
+++ b/src/main/java/openblocks/common/tileentity/TileEntityCannon.java
@@ -130,9 +130,11 @@ public class TileEntityCannon extends SyncedTileEntity implements IPointable, IS
 		// spawn the item approximately at the end of the barrel
 		double yawr = Math.toRadians(currentYaw);
 		double pitchr = Math.toRadians(currentPitch);
-		double x = pos.getX() + 0.5 - Math.sin(yawr) * Math.cos(pitchr);
-		double y = pos.getY() + 0.3 + Math.sin(pitchr);
-		double z = pos.getZ() + 0.5 + Math.cos(yawr) * Math.cos(pitchr);
+		double barrel_length = 0.5;
+		double barrel_base_height = 0.3;
+		double x = pos.getX() + 0.5 - Math.sin(yawr) * Math.cos(pitchr) * barrel_length;
+		double y = pos.getY() + barrel_base_height + Math.sin(pitchr) * barrel_length;
+		double z = pos.getZ() + 0.5 + Math.cos(yawr) * Math.cos(pitchr) * barrel_length;
 
 		// projectileOrigin is not used here, it's used for the calculations below.
 		EntityItem item = new EntityItemProjectile(world, x, y, z, stack);

--- a/src/main/java/openblocks/common/tileentity/TileEntityCannon.java
+++ b/src/main/java/openblocks/common/tileentity/TileEntityCannon.java
@@ -127,8 +127,15 @@ public class TileEntityCannon extends SyncedTileEntity implements IPointable, IS
 		final ITriggerable rpc = createServerRpcProxy(ITriggerable.class);
 		rpc.trigger();
 
+		// spawn the item approximately at the end of the barrel
+		double yawr = Math.toRadians(currentYaw);
+		double pitchr = Math.toRadians(currentPitch);
+		double x = pos.getX() + 0.5 - Math.sin(yawr) * Math.cos(pitchr);
+		double y = pos.getY() + 0.3 + Math.sin(pitchr);
+		double z = pos.getZ() + 0.5 + Math.cos(yawr) * Math.cos(pitchr);
+
 		// projectileOrigin is not used here, it's used for the calculations below.
-		EntityItem item = new EntityItemProjectile(world, pos.getX() + 0.5, pos.getY(), pos.getZ(), stack);
+		EntityItem item = new EntityItemProjectile(world, x, y, z, stack);
 		item.setDefaultPickupDelay();
 
 		// Now that we generate vectors instead of eular angles, this should be revised.

--- a/src/main/java/openblocks/common/tileentity/TileEntityCannon.java
+++ b/src/main/java/openblocks/common/tileentity/TileEntityCannon.java
@@ -130,11 +130,11 @@ public class TileEntityCannon extends SyncedTileEntity implements IPointable, IS
 		// spawn the item approximately at the end of the barrel
 		double yawr = Math.toRadians(currentYaw);
 		double pitchr = Math.toRadians(currentPitch);
-		double barrel_length = 0.5;
-		double barrel_base_height = 0.3;
-		double x = pos.getX() + 0.5 - Math.sin(yawr) * Math.cos(pitchr) * barrel_length;
-		double y = pos.getY() + barrel_base_height + Math.sin(pitchr) * barrel_length;
-		double z = pos.getZ() + 0.5 + Math.cos(yawr) * Math.cos(pitchr) * barrel_length;
+		double barrelLength = 0.5;
+		double barrelBaseHeight = 0.3;
+		double x = pos.getX() + 0.5 - Math.sin(yawr) * Math.cos(pitchr) * barrelLength;
+		double y = pos.getY() + barrelBaseHeight + Math.sin(pitchr) * barrelLength;
+		double z = pos.getZ() + 0.5 + Math.cos(yawr) * Math.cos(pitchr) * barrelLength;
 
 		// projectileOrigin is not used here, it's used for the calculations below.
 		EntityItem item = new EntityItemProjectile(world, x, y, z, stack);


### PR DESCRIPTION
This fixes a couple bugs with ItemCannons:

* The location of the spawned items could collide with the blocks surrounding the cannon in certain directions. This was fixed by making the items spawn roughly where the tip of the cannon barrel is.

* The overridden code in EntityItemProjectile wasn't actually running due to the "!isDead()" check. This was causing the items to be effected by air drag.

* EntityItemProjectile was calling move() and super.onUpdate(), which also calls move. This was causing the velocity to be added twice.

This should close #995 